### PR TITLE
Add e2e tests for recurring issues

### DIFF
--- a/apps/web/tests/e2e/recurring-issues.spec.ts
+++ b/apps/web/tests/e2e/recurring-issues.spec.ts
@@ -1,0 +1,300 @@
+import type { Page } from "@playwright/test"
+import { and, eq } from "drizzle-orm"
+import { registerUser } from "./helpers/auth"
+import { db } from "../../src/db/connection"
+import { users } from "../../src/db/auth-schema"
+import { issues, projects, workspaces } from "../../src/db/schema"
+import { expect, test, type AppFixture } from "./fixtures"
+
+// ─── local helpers ──────────────────────────────────────────────────────────
+
+async function createProject(page: Page, app: AppFixture) {
+  await page.getByLabel(`Create project`).click()
+  const dialog = page.getByRole(`dialog`).filter({
+    has: page.getByRole(`heading`, { name: `Create project` }),
+  })
+  await expect(dialog).toBeVisible()
+  await dialog.getByLabel(`Name`).fill(app.projectName)
+  await expect(dialog.getByLabel(`Prefix`)).toHaveValue(app.projectPrefix)
+  await dialog.getByRole(`button`, { name: `Create project` }).click()
+  await expect(dialog).toBeHidden()
+}
+
+function getWorkspaceSlug(url: string) {
+  const [, , slug] = new URL(url).pathname.split(`/`)
+  return slug
+}
+
+function isoDateOffset(offsetDays: number): string {
+  const d = new Date()
+  d.setUTCDate(d.getUTCDate() + offsetDays)
+  return d.toISOString().slice(0, 10)
+}
+
+async function seedTodoIssues(
+  workspaceSlug: string,
+  projectSlug: string,
+  creatorEmail: string,
+  rows: Array<{ title: string; dueDate?: string }>
+) {
+  const [creator] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, creatorEmail))
+  if (!creator) throw new Error(`Creator not found: ${creatorEmail}`)
+
+  const [workspace] = await db
+    .select({ id: workspaces.id })
+    .from(workspaces)
+    .where(eq(workspaces.slug, workspaceSlug))
+  if (!workspace) throw new Error(`Workspace not found: ${workspaceSlug}`)
+
+  const [project] = await db
+    .select({ id: projects.id })
+    .from(projects)
+    .where(
+      and(
+        eq(projects.workspaceId, workspace.id),
+        eq(projects.slug, projectSlug)
+      )
+    )
+  if (!project) throw new Error(`Project not found: ${projectSlug}`)
+
+  for (const row of rows) {
+    await db.insert(issues).values({
+      projectId: project.id,
+      title: row.title,
+      status: `todo`,
+      priority: `none`,
+      creatorId: creator.id,
+      dueDate: row.dueDate ?? null,
+    })
+  }
+}
+
+// ─── tests ──────────────────────────────────────────────────────────────────
+
+test(`create recurring issue shows Repeat icon in list`, async ({
+  app,
+  page,
+}) => {
+  await registerUser(page, app.owner)
+  await createProject(page, app)
+  await expect(page).toHaveURL(
+    new RegExp(`/w/[^/]+/projects/${app.projectSlug}/?$`)
+  )
+
+  await page.getByRole(`button`, { name: `New Issue` }).click()
+
+  const createDialog = page.locator(`[data-testid="issue-editor-create"]`)
+  await expect(createDialog).toBeVisible()
+
+  // Enable recurrence via the overflow menu
+  await createDialog.getByRole(`button`, { name: `More options` }).click()
+  await page.getByRole(`menuitem`, { name: `Make recurring…` }).click()
+
+  // Recurrence footer should be active
+  await expect(
+    createDialog.getByRole(`button`, { name: `Create recurring issue` })
+  ).toBeVisible()
+  // Inline due-date chip is hidden when recurrence is active
+  await expect(
+    createDialog.getByRole(`button`, { name: `Due date` })
+  ).toBeHidden()
+
+  // Pick today as first-due date (computed inside the browser to match its timezone)
+  await createDialog.getByRole(`button`, { name: /Pick date/ }).click()
+  const todayDataDay = await page.evaluate(() =>
+    new Date().toLocaleDateString(`en-US`)
+  )
+  await page
+    .locator(`[data-slot="calendar"] [data-day="${todayDataDay}"]`)
+    .last()
+    .click()
+  // Dismiss calendar by clicking elsewhere
+  await createDialog.getByPlaceholder(`Issue title`).click()
+
+  // Set interval to 2 (first combobox in the RecurrenceEditor)
+  await createDialog.getByRole(`combobox`).first().click()
+  await page.getByRole(`option`, { name: `2` }).click()
+
+  // Set unit to "days" (second combobox; shows plural labels when interval > 1)
+  await createDialog.getByRole(`combobox`).last().click()
+  await page.getByRole(`option`, { name: `days` }).click()
+
+  await createDialog.getByPlaceholder(`Issue title`).fill(`Laundry`)
+  await createDialog.getByRole(`button`, { name: `Create recurring issue` }).click()
+  await expect(createDialog).toBeHidden()
+
+  await page.reload()
+  await expect(page.getByRole(`heading`, { name: `Issues` })).toBeVisible()
+
+  const todoGroup = page.locator(`[data-testid="issue-group-todo"]`)
+  const laundryRow = todoGroup
+    .locator(`[data-testid^="issue-row-"]`)
+    .filter({ hasText: `Laundry` })
+
+  await expect(laundryRow).toBeVisible()
+  // Repeat icon has aria-label="Recurring" (see issue-list.tsx)
+  await expect(laundryRow.locator(`[aria-label="Recurring"]`)).toBeVisible()
+})
+
+test(`completing a recurring issue spawns a new todo instance; non-recurring does not`, async ({
+  app,
+  page,
+}) => {
+  await registerUser(page, app.owner)
+  await createProject(page, app)
+  await expect(page).toHaveURL(
+    new RegExp(`/w/[^/]+/projects/${app.projectSlug}/?$`)
+  )
+
+  // ── Create the recurring issue ────────────────────────────────────────────
+  await page.getByRole(`button`, { name: `New Issue` }).click()
+  const createDialog = page.locator(`[data-testid="issue-editor-create"]`)
+  await expect(createDialog).toBeVisible()
+
+  await createDialog.getByRole(`button`, { name: `More options` }).click()
+  await page.getByRole(`menuitem`, { name: `Make recurring…` }).click()
+
+  await createDialog.getByRole(`button`, { name: /Pick date/ }).click()
+  const todayDataDay = await page.evaluate(() =>
+    new Date().toLocaleDateString(`en-US`)
+  )
+  await page
+    .locator(`[data-slot="calendar"] [data-day="${todayDataDay}"]`)
+    .last()
+    .click()
+  await createDialog.getByPlaceholder(`Issue title`).click()
+
+  await createDialog.getByRole(`combobox`).first().click()
+  await page.getByRole(`option`, { name: `2` }).click()
+
+  await createDialog.getByRole(`combobox`).last().click()
+  await page.getByRole(`option`, { name: `days` }).click()
+
+  await createDialog.getByPlaceholder(`Issue title`).fill(`Laundry`)
+  await createDialog.getByRole(`button`, { name: `Create recurring issue` }).click()
+  await expect(createDialog).toBeHidden()
+
+  await page.reload()
+  await expect(page.getByRole(`heading`, { name: `Issues` })).toBeVisible()
+
+  // ── Capture the original issue's identifier ───────────────────────────────
+  const todoGroup = page.locator(`[data-testid="issue-group-todo"]`)
+  const laundryRow = todoGroup
+    .locator(`[data-testid^="issue-row-"]`)
+    .filter({ hasText: `Laundry` })
+  await expect(laundryRow).toBeVisible()
+
+  const identifier = (
+    await laundryRow.locator(`span.font-mono`).textContent()
+  )?.trim()
+  if (!identifier) throw new Error(`Could not read issue identifier`)
+
+  // ── Mark the original done via the edit dialog ────────────────────────────
+  const originalRow = page.locator(`[data-testid="issue-row-${identifier}"]`)
+  await originalRow.click()
+
+  const editDialog = page.locator(`[data-testid="issue-editor-edit"]`)
+  await expect(editDialog).toBeVisible()
+
+  await editDialog.getByRole(`button`, { name: `Todo` }).click()
+  await page.getByRole(`menuitem`, { name: `Done` }).click()
+  await editDialog.getByRole(`button`, { name: `Close dialog` }).click()
+  await expect(editDialog).toBeHidden()
+
+  await page.reload()
+  await expect(page.getByRole(`heading`, { name: `Issues` })).toBeVisible()
+
+  // Original moved to Done group
+  await expect(
+    page.locator(
+      `[data-testid="issue-group-done"] [data-testid="issue-row-${identifier}"]`
+    )
+  ).toBeVisible()
+
+  // A new Laundry issue appears in Todo with the Repeat icon (the clone)
+  const cloneRow = page
+    .locator(`[data-testid="issue-group-todo"] [data-testid^="issue-row-"]`)
+    .filter({ hasText: `Laundry` })
+  await expect(cloneRow).toBeVisible()
+  await expect(cloneRow.locator(`[aria-label="Recurring"]`)).toBeVisible()
+
+  // ── Negative: completing a non-recurring issue does not spawn a clone ──────
+  await page.getByRole(`button`, { name: `New Issue` }).click()
+  const createDialog2 = page.locator(`[data-testid="issue-editor-create"]`)
+  await expect(createDialog2).toBeVisible()
+
+  await createDialog2.getByPlaceholder(`Issue title`).fill(`One-shot task`)
+  await createDialog2.getByRole(`button`, { name: `Create issue` }).click()
+  await expect(createDialog2).toBeHidden()
+
+  await page.reload()
+  await expect(page.getByRole(`heading`, { name: `Issues` })).toBeVisible()
+
+  // Non-recurring issue starts in Backlog; find it across all rows
+  const oneShotRow = page
+    .locator(`[data-testid^="issue-row-"]`)
+    .filter({ hasText: `One-shot task` })
+  await expect(oneShotRow).toHaveCount(1)
+
+  const oneShotIdentifier = (
+    await oneShotRow.locator(`span.font-mono`).textContent()
+  )?.trim()
+  if (!oneShotIdentifier) throw new Error(`Could not read one-shot identifier`)
+
+  await oneShotRow.click()
+  const editDialog2 = page.locator(`[data-testid="issue-editor-edit"]`)
+  await expect(editDialog2).toBeVisible()
+
+  await editDialog2.getByRole(`button`, { name: `Backlog` }).click()
+  await page.getByRole(`menuitem`, { name: `Done` }).click()
+  await editDialog2.getByRole(`button`, { name: `Close dialog` }).click()
+  await expect(editDialog2).toBeHidden()
+
+  await page.reload()
+  await expect(page.getByRole(`heading`, { name: `Issues` })).toBeVisible()
+
+  // Exactly one row with "One-shot task" — no clone was created
+  await expect(
+    page
+      .locator(`[data-testid^="issue-row-"]`)
+      .filter({ hasText: `One-shot task` })
+  ).toHaveCount(1)
+})
+
+test(`overdue issues sort before future issues within a status group`, async ({
+  app,
+  page,
+}) => {
+  await registerUser(page, app.owner)
+  await createProject(page, app)
+  await expect(page).toHaveURL(
+    new RegExp(`/w/[^/]+/projects/${app.projectSlug}/?$`)
+  )
+
+  const workspaceSlug = getWorkspaceSlug(page.url())
+
+  // Seed issues in arbitrary insertion order (sort must be by date, not insertion order)
+  await seedTodoIssues(workspaceSlug, app.projectSlug, app.owner.email, [
+    { title: `Tomorrow issue`, dueDate: isoDateOffset(1) },
+    { title: `No-date issue` },
+    { title: `Today issue`, dueDate: isoDateOffset(0) },
+    { title: `Yesterday issue`, dueDate: isoDateOffset(-1) },
+  ])
+
+  await page.reload()
+  await expect(page.getByRole(`heading`, { name: `Issues` })).toBeVisible()
+
+  const todoGroup = page.locator(`[data-testid="issue-group-todo"]`)
+  const rows = todoGroup.locator(`[data-testid^="issue-row-"]`)
+
+  await expect(rows).toHaveCount(4)
+
+  // Assert positional order: yesterday < today < tomorrow < (no date)
+  await expect(rows.nth(0)).toContainText(`Yesterday issue`)
+  await expect(rows.nth(1)).toContainText(`Today issue`)
+  await expect(rows.nth(2)).toContainText(`Tomorrow issue`)
+  await expect(rows.nth(3)).toContainText(`No-date issue`)
+})

--- a/apps/web/tests/e2e/recurring-issues.spec.ts
+++ b/apps/web/tests/e2e/recurring-issues.spec.ts
@@ -1,18 +1,18 @@
 import type { Page } from "@playwright/test"
-import { and, eq } from "drizzle-orm"
+import { eq } from "drizzle-orm"
 import { registerUser } from "./helpers/auth"
-import { db } from "../../src/db/connection"
-import { users } from "../../src/db/auth-schema"
-import { issues, projects, workspaces } from "../../src/db/schema"
+import { db } from "../../../src/db/connection"
+import { issues, projects } from "../../../src/db/schema"
+import { users } from "../../../src/db/auth-schema"
 import { expect, test, type AppFixture } from "./fixtures"
-
-// ─── local helpers ──────────────────────────────────────────────────────────
 
 async function createProject(page: Page, app: AppFixture) {
   await page.getByLabel(`Create project`).click()
+
   const dialog = page.getByRole(`dialog`).filter({
     has: page.getByRole(`heading`, { name: `Create project` }),
   })
+
   await expect(dialog).toBeVisible()
   await dialog.getByLabel(`Name`).fill(app.projectName)
   await expect(dialog.getByLabel(`Prefix`)).toHaveValue(app.projectPrefix)
@@ -20,61 +20,14 @@ async function createProject(page: Page, app: AppFixture) {
   await expect(dialog).toBeHidden()
 }
 
-function getWorkspaceSlug(url: string) {
-  const [, , slug] = new URL(url).pathname.split(`/`)
-  return slug
+function formatDateOnly(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, `0`)
+  const day = String(date.getDate()).padStart(2, `0`)
+  return `${year}-${month}-${day}`
 }
 
-function isoDateOffset(offsetDays: number): string {
-  const d = new Date()
-  d.setUTCDate(d.getUTCDate() + offsetDays)
-  return d.toISOString().slice(0, 10)
-}
-
-async function seedTodoIssues(
-  workspaceSlug: string,
-  projectSlug: string,
-  creatorEmail: string,
-  rows: Array<{ title: string; dueDate?: string }>
-) {
-  const [creator] = await db
-    .select({ id: users.id })
-    .from(users)
-    .where(eq(users.email, creatorEmail))
-  if (!creator) throw new Error(`Creator not found: ${creatorEmail}`)
-
-  const [workspace] = await db
-    .select({ id: workspaces.id })
-    .from(workspaces)
-    .where(eq(workspaces.slug, workspaceSlug))
-  if (!workspace) throw new Error(`Workspace not found: ${workspaceSlug}`)
-
-  const [project] = await db
-    .select({ id: projects.id })
-    .from(projects)
-    .where(
-      and(
-        eq(projects.workspaceId, workspace.id),
-        eq(projects.slug, projectSlug)
-      )
-    )
-  if (!project) throw new Error(`Project not found: ${projectSlug}`)
-
-  for (const row of rows) {
-    await db.insert(issues).values({
-      projectId: project.id,
-      title: row.title,
-      status: `todo`,
-      priority: `none`,
-      creatorId: creator.id,
-      dueDate: row.dueDate ?? null,
-    })
-  }
-}
-
-// ─── tests ──────────────────────────────────────────────────────────────────
-
-test(`create recurring issue shows Repeat icon in list`, async ({
+test(`creates a recurring issue and shows the Repeat icon in the list`, async ({
   app,
   page,
 }) => {
@@ -89,57 +42,60 @@ test(`create recurring issue shows Repeat icon in list`, async ({
   const createDialog = page.locator(`[data-testid="issue-editor-create"]`)
   await expect(createDialog).toBeVisible()
 
-  // Enable recurrence via the overflow menu
+  // Open the overflow menu and enable recurrence
   await createDialog.getByRole(`button`, { name: `More options` }).click()
   await page.getByRole(`menuitem`, { name: `Make recurring…` }).click()
 
-  // Recurrence footer should be active
+  // Footer swaps: submit button becomes "Create recurring issue"
   await expect(
     createDialog.getByRole(`button`, { name: `Create recurring issue` })
   ).toBeVisible()
-  // Inline due-date chip is hidden when recurrence is active
+
+  // Inline due-date chip in the chip row must be hidden when recurrence is active
   await expect(
     createDialog.getByRole(`button`, { name: `Due date` })
   ).toBeHidden()
 
-  // Pick today as first-due date (computed inside the browser to match its timezone)
-  await createDialog.getByRole(`button`, { name: /Pick date/ }).click()
-  const todayDataDay = await page.evaluate(() =>
-    new Date().toLocaleDateString(`en-US`)
-  )
+  // Pick a first-due date in the RecurrenceEditor calendar
+  await createDialog
+    .getByRole(`button`, { name: /^(Pick date|[A-Z][a-z]{2} \d{1,2})$/ })
+    .click()
   await page
-    .locator(`[data-slot="calendar"] [data-day="${todayDataDay}"]`)
+    .locator(`[data-slot="calendar"] [data-day="${app.dueDate.dataDay}"]`)
     .last()
     .click()
-  // Dismiss calendar by clicking elsewhere
+  // Dismiss calendar by clicking the title field
   await createDialog.getByPlaceholder(`Issue title`).click()
 
-  // Set interval to 2 (first combobox in the RecurrenceEditor)
+  // Set interval to 2 (first combobox in the dialog is the interval Select)
   await createDialog.getByRole(`combobox`).first().click()
   await page.getByRole(`option`, { name: `2` }).click()
 
-  // Set unit to "days" (second combobox; shows plural labels when interval > 1)
+  // Set unit to 'day' — with interval=2 the option label is "days"
+  // (second combobox is the unit Select)
   await createDialog.getByRole(`combobox`).last().click()
   await page.getByRole(`option`, { name: `days` }).click()
 
+  // Submit
   await createDialog.getByPlaceholder(`Issue title`).fill(`Laundry`)
-  await createDialog.getByRole(`button`, { name: `Create recurring issue` }).click()
+  await createDialog
+    .getByRole(`button`, { name: `Create recurring issue` })
+    .click()
   await expect(createDialog).toBeHidden()
 
   await page.reload()
   await expect(page.getByRole(`heading`, { name: `Issues` })).toBeVisible()
 
-  const todoGroup = page.locator(`[data-testid="issue-group-todo"]`)
-  const laundryRow = todoGroup
+  const laundryRow = page
+    .locator(`[data-testid="issue-group-todo"]`)
     .locator(`[data-testid^="issue-row-"]`)
     .filter({ hasText: `Laundry` })
 
-  await expect(laundryRow).toBeVisible()
-  // Repeat icon has aria-label="Recurring" (see issue-list.tsx)
-  await expect(laundryRow.locator(`[aria-label="Recurring"]`)).toBeVisible()
+  await expect(laundryRow).toHaveCount(1)
+  await expect(laundryRow.getByLabel(`Recurring`)).toBeVisible()
 })
 
-test(`completing a recurring issue spawns a new todo instance; non-recurring does not`, async ({
+test(`marks a recurring issue done and spawns a clone in Todo`, async ({
   app,
   page,
 }) => {
@@ -149,56 +105,38 @@ test(`completing a recurring issue spawns a new todo instance; non-recurring doe
     new RegExp(`/w/[^/]+/projects/${app.projectSlug}/?$`)
   )
 
-  // ── Create the recurring issue ────────────────────────────────────────────
+  // Create the recurring issue (interval=2, unit=day)
   await page.getByRole(`button`, { name: `New Issue` }).click()
   const createDialog = page.locator(`[data-testid="issue-editor-create"]`)
   await expect(createDialog).toBeVisible()
-
   await createDialog.getByRole(`button`, { name: `More options` }).click()
   await page.getByRole(`menuitem`, { name: `Make recurring…` }).click()
-
-  await createDialog.getByRole(`button`, { name: /Pick date/ }).click()
-  const todayDataDay = await page.evaluate(() =>
-    new Date().toLocaleDateString(`en-US`)
-  )
-  await page
-    .locator(`[data-slot="calendar"] [data-day="${todayDataDay}"]`)
-    .last()
-    .click()
-  await createDialog.getByPlaceholder(`Issue title`).click()
-
+  await expect(
+    createDialog.getByRole(`button`, { name: `Create recurring issue` })
+  ).toBeVisible()
   await createDialog.getByRole(`combobox`).first().click()
   await page.getByRole(`option`, { name: `2` }).click()
-
   await createDialog.getByRole(`combobox`).last().click()
   await page.getByRole(`option`, { name: `days` }).click()
-
   await createDialog.getByPlaceholder(`Issue title`).fill(`Laundry`)
-  await createDialog.getByRole(`button`, { name: `Create recurring issue` }).click()
+  await createDialog
+    .getByRole(`button`, { name: `Create recurring issue` })
+    .click()
   await expect(createDialog).toBeHidden()
 
   await page.reload()
   await expect(page.getByRole(`heading`, { name: `Issues` })).toBeVisible()
 
-  // ── Capture the original issue's identifier ───────────────────────────────
-  const todoGroup = page.locator(`[data-testid="issue-group-todo"]`)
-  const laundryRow = todoGroup
+  // Open the issue and mark it Done
+  const laundryRow = page
+    .locator(`[data-testid="issue-group-todo"]`)
     .locator(`[data-testid^="issue-row-"]`)
     .filter({ hasText: `Laundry` })
-  await expect(laundryRow).toBeVisible()
-
-  const identifier = (
-    await laundryRow.locator(`span.font-mono`).textContent()
-  )?.trim()
-  if (!identifier) throw new Error(`Could not read issue identifier`)
-
-  // ── Mark the original done via the edit dialog ────────────────────────────
-  const originalRow = page.locator(`[data-testid="issue-row-${identifier}"]`)
-  await originalRow.click()
+  await expect(laundryRow).toHaveCount(1)
+  await laundryRow.click()
 
   const editDialog = page.locator(`[data-testid="issue-editor-edit"]`)
   await expect(editDialog).toBeVisible()
-
   await editDialog.getByRole(`button`, { name: `Todo` }).click()
   await page.getByRole(`menuitem`, { name: `Done` }).click()
   await editDialog.getByRole(`button`, { name: `Close dialog` }).click()
@@ -207,64 +145,37 @@ test(`completing a recurring issue spawns a new todo instance; non-recurring doe
   await page.reload()
   await expect(page.getByRole(`heading`, { name: `Issues` })).toBeVisible()
 
-  // Original moved to Done group
-  await expect(
-    page.locator(
-      `[data-testid="issue-group-done"] [data-testid="issue-row-${identifier}"]`
-    )
-  ).toBeVisible()
-
-  // A new Laundry issue appears in Todo with the Repeat icon (the clone)
-  const cloneRow = page
-    .locator(`[data-testid="issue-group-todo"] [data-testid^="issue-row-"]`)
-    .filter({ hasText: `Laundry` })
-  await expect(cloneRow).toBeVisible()
-  await expect(cloneRow.locator(`[aria-label="Recurring"]`)).toBeVisible()
-
-  // ── Negative: completing a non-recurring issue does not spawn a clone ──────
-  await page.getByRole(`button`, { name: `New Issue` }).click()
-  const createDialog2 = page.locator(`[data-testid="issue-editor-create"]`)
-  await expect(createDialog2).toBeVisible()
-
-  await createDialog2.getByPlaceholder(`Issue title`).fill(`One-shot task`)
-  await createDialog2.getByRole(`button`, { name: `Create issue` }).click()
-  await expect(createDialog2).toBeHidden()
-
-  await page.reload()
-  await expect(page.getByRole(`heading`, { name: `Issues` })).toBeVisible()
-
-  // Non-recurring issue starts in Backlog; find it across all rows
-  const oneShotRow = page
-    .locator(`[data-testid^="issue-row-"]`)
-    .filter({ hasText: `One-shot task` })
-  await expect(oneShotRow).toHaveCount(1)
-
-  const oneShotIdentifier = (
-    await oneShotRow.locator(`span.font-mono`).textContent()
-  )?.trim()
-  if (!oneShotIdentifier) throw new Error(`Could not read one-shot identifier`)
-
-  await oneShotRow.click()
-  const editDialog2 = page.locator(`[data-testid="issue-editor-edit"]`)
-  await expect(editDialog2).toBeVisible()
-
-  await editDialog2.getByRole(`button`, { name: `Backlog` }).click()
-  await page.getByRole(`menuitem`, { name: `Done` }).click()
-  await editDialog2.getByRole(`button`, { name: `Close dialog` }).click()
-  await expect(editDialog2).toBeHidden()
-
-  await page.reload()
-  await expect(page.getByRole(`heading`, { name: `Issues` })).toBeVisible()
-
-  // Exactly one row with "One-shot task" — no clone was created
+  // Original is now in Done group
   await expect(
     page
+      .locator(`[data-testid="issue-group-done"]`)
       .locator(`[data-testid^="issue-row-"]`)
-      .filter({ hasText: `One-shot task` })
+      .filter({ hasText: `Laundry` })
   ).toHaveCount(1)
+
+  // Clone appears in Todo group with Repeat icon and due date = today + 2 days
+  const today = new Date()
+  const cloneDate = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate() + 2
+  )
+  const cloneDueDateText = cloneDate.toLocaleDateString(`en-US`, {
+    month: `short`,
+    day: `numeric`,
+  })
+
+  const cloneRow = page
+    .locator(`[data-testid="issue-group-todo"]`)
+    .locator(`[data-testid^="issue-row-"]`)
+    .filter({ hasText: `Laundry` })
+
+  await expect(cloneRow).toHaveCount(1)
+  await expect(cloneRow.getByLabel(`Recurring`)).toBeVisible()
+  await expect(cloneRow).toContainText(cloneDueDateText)
 })
 
-test(`overdue issues sort before future issues within a status group`, async ({
+test(`does not spawn a clone when a non-recurring issue is marked done`, async ({
   app,
   page,
 }) => {
@@ -274,27 +185,136 @@ test(`overdue issues sort before future issues within a status group`, async ({
     new RegExp(`/w/[^/]+/projects/${app.projectSlug}/?$`)
   )
 
-  const workspaceSlug = getWorkspaceSlug(page.url())
+  // Create a plain (non-recurring) issue
+  await page.getByRole(`button`, { name: `New Issue` }).click()
+  const createDialog = page.locator(`[data-testid="issue-editor-create"]`)
+  await expect(createDialog).toBeVisible()
+  await createDialog.getByPlaceholder(`Issue title`).fill(app.issueTitle)
+  await createDialog.getByRole(`button`, { name: `Create issue` }).click()
+  await expect(createDialog).toBeHidden()
 
-  // Seed issues in arbitrary insertion order (sort must be by date, not insertion order)
-  await seedTodoIssues(workspaceSlug, app.projectSlug, app.owner.email, [
-    { title: `Tomorrow issue`, dueDate: isoDateOffset(1) },
-    { title: `No-date issue` },
-    { title: `Today issue`, dueDate: isoDateOffset(0) },
-    { title: `Yesterday issue`, dueDate: isoDateOffset(-1) },
+  await page.reload()
+  await expect(page.getByRole(`heading`, { name: `Issues` })).toBeVisible()
+
+  // Open and mark Done
+  const issueRow = page
+    .locator(`[data-testid^="issue-row-"]`)
+    .filter({ hasText: app.issueTitle })
+  await expect(issueRow).toHaveCount(1)
+  await issueRow.click()
+
+  const editDialog = page.locator(`[data-testid="issue-editor-edit"]`)
+  await expect(editDialog).toBeVisible()
+  await editDialog.getByRole(`button`, { name: `Backlog` }).click()
+  await page.getByRole(`menuitem`, { name: `Done` }).click()
+  await editDialog.getByRole(`button`, { name: `Close dialog` }).click()
+  await expect(editDialog).toBeHidden()
+
+  await page.reload()
+  await expect(page.getByRole(`heading`, { name: `Issues` })).toBeVisible()
+
+  // Exactly one row — in Done, not in Todo (no clone)
+  await expect(
+    page
+      .locator(`[data-testid="issue-group-done"]`)
+      .locator(`[data-testid^="issue-row-"]`)
+      .filter({ hasText: app.issueTitle })
+  ).toHaveCount(1)
+
+  await expect(
+    page
+      .locator(`[data-testid="issue-group-todo"]`)
+      .locator(`[data-testid^="issue-row-"]`)
+      .filter({ hasText: app.issueTitle })
+  ).toHaveCount(0)
+})
+
+test(`shows overdue issues first within the Todo status group`, async ({
+  app,
+  page,
+}) => {
+  await registerUser(page, app.owner)
+  await createProject(page, app)
+  await expect(page).toHaveURL(
+    new RegExp(`/w/[^/]+/projects/${app.projectSlug}/?$`)
+  )
+
+  // Resolve the creator and project IDs from the DB
+  const [ownerRow] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, app.owner.email))
+
+  const [projectRow] = await db
+    .select({ id: projects.id })
+    .from(projects)
+    .where(eq(projects.slug, app.projectSlug))
+    .limit(1)
+
+  if (!ownerRow || !projectRow) {
+    throw new Error(`Could not find owner or project in DB`)
+  }
+
+  const today = new Date()
+  const yesterday = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate() - 1
+  )
+  const tomorrow = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate() + 1
+  )
+
+  // Seed 4 issues directly into the DB with different due dates
+  await db.insert(issues).values([
+    {
+      projectId: projectRow.id,
+      title: `Yesterday Task`,
+      status: `todo`,
+      priority: `none`,
+      dueDate: formatDateOnly(yesterday),
+      creatorId: ownerRow.id,
+    },
+    {
+      projectId: projectRow.id,
+      title: `Today Task`,
+      status: `todo`,
+      priority: `none`,
+      dueDate: formatDateOnly(today),
+      creatorId: ownerRow.id,
+    },
+    {
+      projectId: projectRow.id,
+      title: `Tomorrow Task`,
+      status: `todo`,
+      priority: `none`,
+      dueDate: formatDateOnly(tomorrow),
+      creatorId: ownerRow.id,
+    },
+    {
+      projectId: projectRow.id,
+      title: `No Due Date Task`,
+      status: `todo`,
+      priority: `none`,
+      creatorId: ownerRow.id,
+    },
   ])
 
+  // Reload so Electric picks up the newly seeded issues
   await page.reload()
   await expect(page.getByRole(`heading`, { name: `Issues` })).toBeVisible()
 
   const todoGroup = page.locator(`[data-testid="issue-group-todo"]`)
   const rows = todoGroup.locator(`[data-testid^="issue-row-"]`)
 
+  // Wait for all 4 issues to appear
   await expect(rows).toHaveCount(4)
 
-  // Assert positional order: yesterday < today < tomorrow < (no date)
-  await expect(rows.nth(0)).toContainText(`Yesterday issue`)
-  await expect(rows.nth(1)).toContainText(`Today issue`)
-  await expect(rows.nth(2)).toContainText(`Tomorrow issue`)
-  await expect(rows.nth(3)).toContainText(`No-date issue`)
+  // Sort order: overdue (yesterday) first, then by dueDate asc, then no-dueDate last
+  await expect(rows.nth(0)).toContainText(`Yesterday Task`)
+  await expect(rows.nth(1)).toContainText(`Today Task`)
+  await expect(rows.nth(2)).toContainText(`Tomorrow Task`)
+  await expect(rows.nth(3)).toContainText(`No Due Date Task`)
 })


### PR DESCRIPTION
## Summary

- **Scenario 1 — Create recurring → list shows it**: opens the create dialog, enables recurrence via the `⋯` overflow menu, picks today as first-due date, sets interval=2 unit=days, submits as "Laundry", and asserts the issue appears in the Todo group with a `Repeat` icon (`aria-label="Recurring"`).
- **Scenario 2 — Complete recurring → spawn next instance**: creates the same recurring issue via UI, marks it Done through the edit dialog, reloads, and asserts the original is in Done while a new "Laundry" clone with the Repeat icon appears in Todo. Includes a negative case: marking a plain (non-recurring) issue Done produces no clone.
- **Scenario 3 — Overdue-first sort within a status group**: seeds four Todo issues with due dates yesterday / today / tomorrow / none directly via Drizzle (matching the pattern used by other specs), reloads the project board, and asserts the rows appear in that exact order.

## Notes

- No production code under `src/` was modified.
- This is a follow-up to the recurring-issues feature shipped 2026-04-26.
- **The suite could not be run in the sandbox** — Docker is unavailable (`/var/run/docker.sock` missing), so neither Postgres nor Electric could be started. The specs are structurally correct and pass `tsc --noEmit` with no new errors. Please run `bun run backend:up && bun test:e2e` locally (or in CI with infra) before merging.

https://claude.ai/code/session_0149XToTuXsS6YgYaimzomam

---
_Generated by [Claude Code](https://claude.ai/code/session_0149XToTuXsS6YgYaimzomam)_