### PR TITLE
Add standalone push-relay service for configurable FCM notifications

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,16 +20,18 @@ Real-time issue tracker.
 exponential/
 ├── apps/
 │   ├── web/        # TanStack Start app (the issue tracker)
+│   ├── push-relay/ # Standalone push notification relay (Hono/Bun, separately deployed)
 │   ├── marketing/  # Marketing site (Vite + React, deployed via Coolify)
 │   └── android/    # Native Kotlin / Jetpack Compose app (in progress)
 ├── packages/       # Shared packages (db-schema, api-contracts, …)
 ├── docker-compose.yaml
 ├── Caddyfile
-├── Dockerfile      # Builds the web app image; build context = repo root
+├── Dockerfile              # Builds the web app image; build context = repo root
+├── Dockerfile.push-relay   # Builds the push relay image; build context = repo root
 └── package.json    # bun workspaces, dispatcher scripts
 ```
 
-Workspace package names: `@exp/web`, `@exp/marketing` (and future `@exp/db-schema`, etc.).
+Workspace package names: `@exp/web`, `@exp/push-relay`, `@exp/marketing` (and future `@exp/db-schema`, etc.).
 
 ## Commands
 
@@ -39,6 +41,8 @@ All commands run from the repo root unless noted.
 bun install                        # Install workspace deps (run from root)
 bun dev                            # Start web dev server (apps/web, localhost:5173)
 bun run dev:marketing              # Start marketing dev server (apps/marketing)
+bun run dev:push-relay             # Start push relay dev server (apps/push-relay, localhost:4001)
+bun run start:push-relay           # Start push relay in production mode
 bun run build                      # Build web + marketing
 bun run build:web                  # Build only the web app
 bun run typecheck                  # Typecheck the web app
@@ -250,7 +254,8 @@ GOOGLE_CLIENT_ID              # Google OAuth client ID (required for login or Ca
 GOOGLE_CLIENT_SECRET          # Google OAuth client secret
 GOOGLE_LOGIN_ENABLED          # Show "Sign in with Google" on login/register (default: false)
 GOOGLE_CALENDAR_ENABLED       # Enable Google Calendar integration (default: false)
-FIREBASE_SERVICE_ACCOUNT_JSON # Firebase service account key (JSON string) for FCM push delivery
+PUSH_RELAY_URL                # URL of the push-relay service (e.g. https://push.yourapp.com)
+PUSH_RELAY_SECRET             # Shared secret — must match RELAY_SECRET on the push-relay service
 ```
 
 ## Integrations

--- a/Dockerfile.push-relay
+++ b/Dockerfile.push-relay
@@ -1,0 +1,33 @@
+FROM oven/bun:1 AS builder
+WORKDIR /app
+
+# Copy workspace manifests needed for bun install
+COPY package.json bun.lock bunfig.toml ./
+COPY apps/push-relay/package.json apps/push-relay/package.json
+COPY packages/tsconfig/package.json packages/tsconfig/package.json
+# Stub out other workspace package.json files so bun install resolves correctly
+COPY apps/web/package.json apps/web/package.json
+COPY apps/marketing/package.json apps/marketing/package.json
+COPY packages/db-schema/package.json packages/db-schema/package.json
+COPY packages/electric-protocol/package.json packages/electric-protocol/package.json
+
+RUN bun install --frozen-lockfile
+
+COPY packages/tsconfig packages/tsconfig
+COPY apps/push-relay apps/push-relay
+
+FROM oven/bun:1
+WORKDIR /app
+
+COPY --from=builder /app/node_modules node_modules
+COPY --from=builder /app/apps/push-relay apps/push-relay
+COPY --from=builder /app/packages/tsconfig packages/tsconfig
+COPY --from=builder /app/package.json .
+COPY --from=builder /app/bunfig.toml .
+
+EXPOSE 4001
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+  CMD bun -e "fetch('http://localhost:4001/healthz').then(r=>process.exit(r.ok?0:1))"
+
+CMD ["bun", "apps/push-relay/src/index.ts"]

--- a/apps/push-relay/.env.example
+++ b/apps/push-relay/.env.example
@@ -1,0 +1,9 @@
+# Firebase service account key JSON (single-line string) — required
+FIREBASE_SERVICE_ACCOUNT_JSON=
+
+# Shared secret — must match PUSH_RELAY_SECRET in the web app
+# Generate: openssl rand -hex 32
+RELAY_SECRET=
+
+# Port to listen on (default: 4001)
+# PORT=4001

--- a/apps/push-relay/package.json
+++ b/apps/push-relay/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@exp/push-relay",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "bun --hot src/index.ts",
+    "start": "bun src/index.ts",
+    "typecheck": "tsc --noEmit",
+    "lint:check": "eslint .",
+    "lint": "eslint . --fix"
+  },
+  "dependencies": {
+    "firebase-admin": "^13.8.0",
+    "hono": "^4.7.11",
+    "zod": "^4.0.14"
+  },
+  "devDependencies": {
+    "@exp/tsconfig": "workspace:*",
+    "@types/bun": "latest",
+    "typescript": "^5.7.2"
+  }
+}

--- a/apps/push-relay/src/index.ts
+++ b/apps/push-relay/src/index.ts
@@ -1,0 +1,139 @@
+import { Hono } from "hono"
+import { cert, getApps, initializeApp, type App } from "firebase-admin/app"
+import { getMessaging } from "firebase-admin/messaging"
+import { z } from "zod"
+
+// ── Firebase init (lazy singleton) ───────────────────────────────────────────
+
+let firebaseApp: App | null | undefined
+
+function getFirebaseApp(): App | null {
+  if (firebaseApp !== undefined) return firebaseApp
+
+  const raw = process.env.FIREBASE_SERVICE_ACCOUNT_JSON
+  if (!raw) {
+    console.warn(`[push-relay] FIREBASE_SERVICE_ACCOUNT_JSON not set — relay disabled`)
+    firebaseApp = null
+    return firebaseApp
+  }
+  try {
+    const creds = JSON.parse(raw)
+    firebaseApp =
+      getApps()[0] ??
+      initializeApp({
+        credential: cert({
+          projectId: creds.project_id,
+          clientEmail: creds.client_email,
+          privateKey: creds.private_key,
+        }),
+      })
+    return firebaseApp
+  } catch (err) {
+    console.error(`[push-relay] Failed to init firebase-admin:`, err)
+    firebaseApp = null
+    return firebaseApp
+  }
+}
+
+// ── Validation ────────────────────────────────────────────────────────────────
+
+const sendSchema = z.object({
+  tokens: z.array(z.string().min(1)).min(1).max(500),
+  notification: z.object({
+    title: z.string().min(1),
+    body: z.string().optional(),
+  }),
+  data: z.record(z.string(), z.string()),
+})
+
+// ── Dead-token error codes per Firebase docs ──────────────────────────────────
+
+const DEAD_CODES = new Set([
+  `messaging/registration-token-not-registered`,
+  `messaging/invalid-registration-token`,
+])
+
+// ── Hono app ──────────────────────────────────────────────────────────────────
+
+const app = new Hono()
+
+// Unauthenticated health check for Docker HEALTHCHECK / uptime monitors
+app.get(`/healthz`, (c) => c.json({ ok: true }))
+
+// Auth middleware scoped to /send only
+app.use(`/send`, async (c, next) => {
+  const secret = process.env.RELAY_SECRET
+  if (!secret) {
+    return c.json({ error: `RELAY_SECRET not configured` }, 500)
+  }
+  const auth = c.req.header(`Authorization`)
+  if (auth !== `Bearer ${secret}`) {
+    return c.json({ error: `Unauthorized` }, 401)
+  }
+  await next()
+})
+
+app.post(`/send`, async (c) => {
+  const firebase = getFirebaseApp()
+  if (!firebase) {
+    return c.json({ error: `Firebase not configured` }, 503)
+  }
+
+  const body = await c.req.json().catch(() => null)
+  const parsed = sendSchema.safeParse(body)
+  if (!parsed.success) {
+    return c.json({ error: `Bad request`, issues: parsed.error.issues }, 400)
+  }
+
+  const { tokens, notification, data } = parsed.data
+  const messaging = getMessaging(firebase)
+
+  let response
+  try {
+    response = await messaging.sendEachForMulticast({
+      tokens,
+      notification: { title: notification.title, body: notification.body },
+      data,
+      android: {
+        priority: `high`,
+        notification: { channelId: `issues_default` },
+      },
+      apns: {
+        headers: { "apns-priority": `10` },
+        payload: {
+          aps: {
+            alert: { title: notification.title, body: notification.body },
+            sound: `default`,
+            contentAvailable: true,
+          },
+        },
+      },
+    })
+  } catch (err) {
+    console.error(`[push-relay] FCM multicast failed:`, err)
+    return c.json({ error: `FCM error` }, 500)
+  }
+
+  const invalidTokens: string[] = []
+  response.responses.forEach((res, i) => {
+    if (res.success) return
+    const code = res.error?.code
+    if (code && DEAD_CODES.has(code)) {
+      invalidTokens.push(tokens[i])
+    } else {
+      console.error(`[push-relay] send error token=${tokens[i]}`, res.error)
+    }
+  })
+
+  return c.json({ invalidTokens })
+})
+
+// ── Start ─────────────────────────────────────────────────────────────────────
+
+const port = parseInt(process.env.PORT ?? `4001`, 10)
+console.log(`[push-relay] listening on :${port}`)
+
+export default {
+  port,
+  fetch: app.fetch,
+}

--- a/apps/push-relay/tsconfig.json
+++ b/apps/push-relay/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@exp/tsconfig/base.json",
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["bun-types"],
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true
+  }
+}

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -53,9 +53,11 @@ S3_REGION=garage
 # GOOGLE_LOGIN_ENABLED=false
 # GOOGLE_CALENDAR_ENABLED=false
 
-# --- Firebase Cloud Messaging (push notification delivery) -------------
-# Service account key JSON as a single-line string
-# FIREBASE_SERVICE_ACCOUNT_JSON=
+# --- Push notifications (via push-relay service) -----------------------
+# URL of the push-relay service (e.g. https://push.yourapp.com)
+# PUSH_RELAY_URL=
+# Shared secret — must match RELAY_SECRET in the push-relay service
+# PUSH_RELAY_SECRET=
 
 # --- MCP server (static Bearer token; tool calls run as MCP_USER_EMAIL) -
 MCP_API_TOKEN=

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -47,7 +47,6 @@
     "date-fns": "^4.1.0",
     "drizzle-orm": "^0.39.0",
     "drizzle-zod": "^0.7.1",
-    "firebase-admin": "^13.8.0",
     "google-auth-library": "^10.5.0",
     "lucide-react": "^0.544.0",
     "nitro": "3.0.1-alpha.1",

--- a/apps/web/src/lib/fcm.ts
+++ b/apps/web/src/lib/fcm.ts
@@ -1,39 +1,30 @@
-import { cert, getApps, initializeApp, type App } from "firebase-admin/app"
-import { getMessaging } from "firebase-admin/messaging"
 import { eq, inArray } from "drizzle-orm"
 import { db } from "@/db/connection"
 import { fcmTokens } from "@/db/schema"
 
-let app: App | null | undefined
+// ── Relay config (lazy singleton) ─────────────────────────────────────────────
 
-function getApp(): App | null {
-  if (app !== undefined) return app
-  const raw = process.env.FIREBASE_SERVICE_ACCOUNT_JSON
-  if (!raw) {
+type RelayConfig = { url: string; secret: string }
+
+let relayConfig: RelayConfig | null | undefined
+
+function getRelayConfig(): RelayConfig | null {
+  if (relayConfig !== undefined) return relayConfig
+
+  const url = process.env.PUSH_RELAY_URL
+  const secret = process.env.PUSH_RELAY_SECRET
+  if (!url || !secret) {
     console.warn(
-      `[fcm] FIREBASE_SERVICE_ACCOUNT_JSON not set — push notifications disabled`
+      `[fcm] PUSH_RELAY_URL or PUSH_RELAY_SECRET not set — push notifications disabled`
     )
-    app = null
-    return app
+    relayConfig = null
+    return relayConfig
   }
-  try {
-    const credentials = JSON.parse(raw)
-    app =
-      getApps()[0] ??
-      initializeApp({
-        credential: cert({
-          projectId: credentials.project_id,
-          clientEmail: credentials.client_email,
-          privateKey: credentials.private_key,
-        }),
-      })
-    return app
-  } catch (err) {
-    console.error(`[fcm] Failed to init firebase-admin:`, err)
-    app = null
-    return app
-  }
+  relayConfig = { url, secret }
+  return relayConfig
 }
+
+// ── Types ─────────────────────────────────────────────────────────────────────
 
 export type FcmPayload = {
   title: string
@@ -41,48 +32,52 @@ export type FcmPayload = {
   data: Record<string, string>
 }
 
+// ── Main export ───────────────────────────────────────────────────────────────
+
 export async function sendToUser(
   userId: string,
   payload: FcmPayload
 ): Promise<void> {
-  const firebase = getApp()
-  if (!firebase) return
+  const cfg = getRelayConfig()
+  if (!cfg) return
 
-  const tokens = await db
+  const rows = await db
     .select({ token: fcmTokens.token })
     .from(fcmTokens)
     .where(eq(fcmTokens.userId, userId))
 
-  if (tokens.length === 0) return
+  if (rows.length === 0) return
 
-  const tokenStrings = tokens.map((row) => row.token)
-  const messaging = getMessaging(firebase)
-  const response = await messaging.sendEachForMulticast({
-    tokens: tokenStrings,
-    notification: { title: payload.title, body: payload.body },
-    data: payload.data,
-    android: {
-      priority: `high`,
-      notification: { channelId: `issues_default` },
-    },
-  })
+  const tokens = rows.map((r) => r.token)
 
-  // Prune dead tokens — codes from
-  // https://firebase.google.com/docs/cloud-messaging/manage-tokens
-  const dead: string[] = []
-  response.responses.forEach((res, i) => {
-    if (res.success) return
-    const code = res.error?.code
-    if (
-      code === `messaging/registration-token-not-registered` ||
-      code === `messaging/invalid-registration-token`
-    ) {
-      dead.push(tokenStrings[i])
-    } else {
-      console.error(`[fcm] send error for token`, tokenStrings[i], res.error)
+  let invalidTokens: string[] = []
+  try {
+    const res = await fetch(`${cfg.url}/send`, {
+      method: `POST`,
+      headers: {
+        "Content-Type": `application/json`,
+        Authorization: `Bearer ${cfg.secret}`,
+      },
+      body: JSON.stringify({
+        tokens,
+        notification: { title: payload.title, body: payload.body },
+        data: payload.data,
+      }),
+    })
+
+    if (!res.ok) {
+      console.error(`[fcm] relay responded ${res.status}:`, await res.text())
+      return
     }
-  })
-  if (dead.length > 0) {
-    await db.delete(fcmTokens).where(inArray(fcmTokens.token, dead))
+
+    const json = (await res.json()) as { invalidTokens?: string[] }
+    invalidTokens = json.invalidTokens ?? []
+  } catch (err) {
+    console.error(`[fcm] relay request failed:`, err)
+    return
+  }
+
+  if (invalidTokens.length > 0) {
+    await db.delete(fcmTokens).where(inArray(fcmTokens.token, invalidTokens))
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -34,9 +34,23 @@
         "vite": "^7.1.7",
       },
     },
+    "apps/push-relay": {
+      "name": "@exp/push-relay",
+      "version": "0.1.0",
+      "dependencies": {
+        "firebase-admin": "^13.8.0",
+        "hono": "^4.7.11",
+        "zod": "^4.0.14",
+      },
+      "devDependencies": {
+        "@exp/tsconfig": "workspace:*",
+        "@types/bun": "latest",
+        "typescript": "^5.7.2",
+      },
+    },
     "apps/web": {
       "name": "@exp/web",
-      "version": "0.10.3",
+      "version": "0.13.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.888.0",
         "@electric-sql/client": "^1.2.0",
@@ -65,7 +79,6 @@
         "date-fns": "^4.1.0",
         "drizzle-orm": "^0.39.0",
         "drizzle-zod": "^0.7.1",
-        "firebase-admin": "^13.8.0",
         "google-auth-library": "^10.5.0",
         "lucide-react": "^0.544.0",
         "nitro": "3.0.1-alpha.1",
@@ -111,6 +124,10 @@
         "drizzle-zod": "^0.7.1",
         "zod": "^4.0.14",
       },
+    },
+    "packages/electric-protocol": {
+      "name": "@exp/electric-protocol",
+      "version": "0.0.0",
     },
     "packages/tsconfig": {
       "name": "@exp/tsconfig",
@@ -410,7 +427,11 @@
 
     "@exp/db-schema": ["@exp/db-schema@workspace:packages/db-schema"],
 
+    "@exp/electric-protocol": ["@exp/electric-protocol@workspace:packages/electric-protocol"],
+
     "@exp/marketing": ["@exp/marketing@workspace:apps/marketing"],
+
+    "@exp/push-relay": ["@exp/push-relay@workspace:apps/push-relay"],
 
     "@exp/tsconfig": ["@exp/tsconfig@workspace:packages/tsconfig"],
 
@@ -1094,6 +1115,8 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/caseless": ["@types/caseless@0.12.5", "", {}, "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
@@ -1269,6 +1292,8 @@
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -2276,7 +2301,7 @@
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
-    "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "readable-web-to-node-stream": ["readable-web-to-node-stream@3.0.4", "", { "dependencies": { "readable-stream": "^4.7.0" } }, "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw=="],
 
@@ -2842,8 +2867,6 @@
 
     "drizzle-kit/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
-    "duplexify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
-
     "eciesjs/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
     "eciesjs/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
@@ -2909,6 +2932,8 @@
     "prosemirror-markdown/@types/markdown-it": ["@types/markdown-it@14.1.2", "", { "dependencies": { "@types/linkify-it": "^5", "@types/mdurl": "^2" } }, "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog=="],
 
     "radix-ui/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "readable-web-to-node-stream/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "scripts": {
     "dev": "bun --filter @exp/web dev",
     "dev:marketing": "bun --filter @exp/marketing dev",
+    "dev:push-relay": "bun --filter @exp/push-relay dev",
+    "start:push-relay": "bun --filter @exp/push-relay start",
     "build": "bun --filter @exp/web build && bun --filter @exp/marketing build",
     "build:web": "bun --filter @exp/web build",
     "build:marketing": "bun --filter @exp/marketing build",


### PR DESCRIPTION
Extracts Firebase push delivery into apps/push-relay — a lightweight
Hono/Bun HTTP API that holds Firebase credentials and delivers to FCM
(Android, iOS via APNs, web). Self-hosted web instances no longer need
a Firebase service account; they configure PUSH_RELAY_URL + PUSH_RELAY_SECRET
to point at the developer-hosted relay.

- apps/push-relay: new Hono service with POST /send and GET /healthz
- Adds apns block to FCM multicast for proper iOS delivery
- apps/web/src/lib/fcm.ts: replace firebase-admin with fetch() to relay
- Remove firebase-admin from apps/web dependencies
- Dockerfile.push-relay: standalone container image for the relay
- Update env examples and CLAUDE.md

https://claude.ai/code/session_01Up3P6uhKjaDybMGCxmk41c