### PR TITLE
Remove auth from push relay — open relay protected by FCM token speci…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,7 +255,6 @@ GOOGLE_CLIENT_SECRET          # Google OAuth client secret
 GOOGLE_LOGIN_ENABLED          # Show "Sign in with Google" on login/register (default: false)
 GOOGLE_CALENDAR_ENABLED       # Enable Google Calendar integration (default: false)
 PUSH_RELAY_URL                # URL of the push-relay service (e.g. https://push.yourapp.com)
-PUSH_RELAY_SECRET             # Shared secret — must match RELAY_SECRET on the push-relay service
 ```
 
 ## Integrations

--- a/apps/push-relay/.env.example
+++ b/apps/push-relay/.env.example
@@ -1,9 +1,5 @@
 # Firebase service account key JSON (single-line string) — required
 FIREBASE_SERVICE_ACCOUNT_JSON=
 
-# Shared secret — must match PUSH_RELAY_SECRET in the web app
-# Generate: openssl rand -hex 32
-RELAY_SECRET=
-
 # Port to listen on (default: 4001)
 # PORT=4001

--- a/apps/push-relay/src/index.ts
+++ b/apps/push-relay/src/index.ts
@@ -60,19 +60,6 @@ const app = new Hono()
 // Unauthenticated health check for Docker HEALTHCHECK / uptime monitors
 app.get(`/healthz`, (c) => c.json({ ok: true }))
 
-// Auth middleware scoped to /send only
-app.use(`/send`, async (c, next) => {
-  const secret = process.env.RELAY_SECRET
-  if (!secret) {
-    return c.json({ error: `RELAY_SECRET not configured` }, 500)
-  }
-  const auth = c.req.header(`Authorization`)
-  if (auth !== `Bearer ${secret}`) {
-    return c.json({ error: `Unauthorized` }, 401)
-  }
-  await next()
-})
-
 app.post(`/send`, async (c) => {
   const firebase = getFirebaseApp()
   if (!firebase) {

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -56,8 +56,6 @@ S3_REGION=garage
 # --- Push notifications (via push-relay service) -----------------------
 # URL of the push-relay service (e.g. https://push.yourapp.com)
 # PUSH_RELAY_URL=
-# Shared secret — must match RELAY_SECRET in the push-relay service
-# PUSH_RELAY_SECRET=
 
 # --- MCP server (static Bearer token; tool calls run as MCP_USER_EMAIL) -
 MCP_API_TOKEN=

--- a/apps/web/src/lib/fcm.ts
+++ b/apps/web/src/lib/fcm.ts
@@ -4,24 +4,19 @@ import { fcmTokens } from "@/db/schema"
 
 // ── Relay config (lazy singleton) ─────────────────────────────────────────────
 
-type RelayConfig = { url: string; secret: string }
+let relayUrl: string | null | undefined
 
-let relayConfig: RelayConfig | null | undefined
-
-function getRelayConfig(): RelayConfig | null {
-  if (relayConfig !== undefined) return relayConfig
+function getRelayUrl(): string | null {
+  if (relayUrl !== undefined) return relayUrl
 
   const url = process.env.PUSH_RELAY_URL
-  const secret = process.env.PUSH_RELAY_SECRET
-  if (!url || !secret) {
-    console.warn(
-      `[fcm] PUSH_RELAY_URL or PUSH_RELAY_SECRET not set — push notifications disabled`
-    )
-    relayConfig = null
-    return relayConfig
+  if (!url) {
+    console.warn(`[fcm] PUSH_RELAY_URL not set — push notifications disabled`)
+    relayUrl = null
+    return relayUrl
   }
-  relayConfig = { url, secret }
-  return relayConfig
+  relayUrl = url
+  return relayUrl
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -38,8 +33,8 @@ export async function sendToUser(
   userId: string,
   payload: FcmPayload
 ): Promise<void> {
-  const cfg = getRelayConfig()
-  if (!cfg) return
+  const url = getRelayUrl()
+  if (!url) return
 
   const rows = await db
     .select({ token: fcmTokens.token })
@@ -52,12 +47,9 @@ export async function sendToUser(
 
   let invalidTokens: string[] = []
   try {
-    const res = await fetch(`${cfg.url}/send`, {
+    const res = await fetch(`${url}/send`, {
       method: `POST`,
-      headers: {
-        "Content-Type": `application/json`,
-        Authorization: `Bearer ${cfg.secret}`,
-      },
+      headers: { "Content-Type": `application/json` },
       body: JSON.stringify({
         tokens,
         notification: { title: payload.title, body: payload.body },


### PR DESCRIPTION
…ficity

The shared secret provided no real security since all self-hosters would use the same value. FCM tokens are device-specific and unguessable, so the relay is naturally protected against abuse without it. Simplifies self-hoster setup to a single PUSH_RELAY_URL env var.

https://claude.ai/code/session_01Up3P6uhKjaDybMGCxmk41c