### PR TITLE
macOS web-UI parity + workspace member-guard fix (server + all clients)

### DIFF
--- a/apps/android/app/src/main/java/com/exponential/app/ui/settings/WorkspaceSettingsScreen.kt
+++ b/apps/android/app/src/main/java/com/exponential/app/ui/settings/WorkspaceSettingsScreen.kt
@@ -223,10 +223,13 @@ private fun MembersTab(state: WorkspaceSettingsState, viewModel: WorkspaceSettin
                 Text("Invite")
             }
         }
+        // A workspace must always keep at least one owner.
+        val ownerCount = state.members.count { it.member.role == DomainContract.workspaceRoleOwner }
         Column(Modifier.fillMaxWidth().glassSection().padding(vertical = 4.dp)) {
             state.members.forEachIndexed { i, row ->
                 if (i > 0) HorizontalDivider(color = Color.White.copy(alpha = 0.06f))
                 val isYou = row.member.userId == state.currentUserId
+                val isLastOwner = row.member.role == DomainContract.workspaceRoleOwner && ownerCount <= 1
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp),
@@ -255,29 +258,48 @@ private fun MembersTab(state: WorkspaceSettingsState, viewModel: WorkspaceSettin
                             Icon(Icons.Filled.MoreVert, contentDescription = "Member actions")
                         }
                         DropdownMenu(expanded = rowMenu, onDismissRequest = { rowMenu = false }) {
-                            // Role options, hiding the role already applied (parity with iOS).
-                            DomainContract.workspaceRoleValues.filter { it != row.member.role }.forEach { role ->
+                            // Only owner/member are assignable (agents are managed
+                            // separately). The last owner can't be demoted or leave.
+                            if (row.member.role != DomainContract.workspaceRoleOwner) {
                                 DropdownMenuItem(
-                                    text = { Text("Make $role") },
+                                    text = { Text("Make owner") },
                                     onClick = {
                                         rowMenu = false
-                                        viewModel.updateRole(row.member.id, role)
+                                        viewModel.updateRole(row.member.id, DomainContract.workspaceRoleOwner)
                                     },
                                 )
                             }
-                            HorizontalDivider()
-                            DropdownMenuItem(
-                                text = {
-                                    Text(
-                                        if (isYou) "Leave workspace" else "Remove",
-                                        color = MaterialTheme.colorScheme.error,
+                            if (row.member.role != DomainContract.workspaceRoleMember) {
+                                DropdownMenuItem(
+                                    text = { Text("Make member") },
+                                    enabled = !isLastOwner,
+                                    onClick = {
+                                        rowMenu = false
+                                        viewModel.updateRole(row.member.id, DomainContract.workspaceRoleMember)
+                                    },
+                                )
+                            }
+                            if (isYou) {
+                                if (!isLastOwner) {
+                                    HorizontalDivider()
+                                    DropdownMenuItem(
+                                        text = { Text("Leave workspace", color = MaterialTheme.colorScheme.error) },
+                                        onClick = {
+                                            rowMenu = false
+                                            viewModel.removeMember(row.member.id)
+                                        },
                                     )
-                                },
-                                onClick = {
-                                    rowMenu = false
-                                    viewModel.removeMember(row.member.id)
-                                },
-                            )
+                                }
+                            } else {
+                                HorizontalDivider()
+                                DropdownMenuItem(
+                                    text = { Text("Remove", color = MaterialTheme.colorScheme.error) },
+                                    onClick = {
+                                        rowMenu = false
+                                        viewModel.removeMember(row.member.id)
+                                    },
+                                )
+                            }
                         }
                     }
                 }

--- a/apps/ios/ExpCore/Sources/API/AdminApi.swift
+++ b/apps/ios/ExpCore/Sources/API/AdminApi.swift
@@ -66,22 +66,6 @@ public struct AdminOwner: Decodable, Sendable {
     }
 }
 
-public struct AdminUsersResult: Decodable, Sendable {
-    public let users: [AdminUser]
-
-    public init(users: [AdminUser]) {
-        self.users = users
-    }
-}
-
-public struct AdminWorkspacesResult: Decodable, Sendable {
-    public let workspaces: [AdminWorkspace]
-
-    public init(workspaces: [AdminWorkspace]) {
-        self.workspaces = workspaces
-    }
-}
-
 public struct SetAdminInput: Encodable, Sendable {
     public let userId: String
     public let isAdmin: Bool
@@ -100,8 +84,6 @@ public struct DeleteUserInput: Encodable, Sendable {
     }
 }
 
-private struct EmptyAdminInput: Encodable {}
-
 public final class AdminApi: Sendable {
     private let trpc: TrpcClient
 
@@ -110,8 +92,8 @@ public final class AdminApi: Sendable {
     }
 
     public func listUsers(accountId: String) async throws -> [AdminUser] {
-        let result: AdminUsersResult = try await trpc.mutation(accountId: accountId, path: "admin.listUsers", input: EmptyAdminInput())
-        return result.users
+        // Server defines admin.listUsers as a `.query` (GET) returning a bare array.
+        try await trpc.query(accountId: accountId, path: "admin.listUsers")
     }
 
     public func setUserAdmin(accountId: String, userId: String, isAdmin: Bool) async throws {
@@ -123,8 +105,8 @@ public final class AdminApi: Sendable {
     }
 
     public func listWorkspaces(accountId: String) async throws -> [AdminWorkspace] {
-        let result: AdminWorkspacesResult = try await trpc.mutation(accountId: accountId, path: "admin.listWorkspaces", input: EmptyAdminInput())
-        return result.workspaces
+        // Server defines admin.listWorkspaces as a `.query` (GET) returning a bare array.
+        try await trpc.query(accountId: accountId, path: "admin.listWorkspaces")
     }
 
     public func deleteWorkspace(accountId: String, workspaceId: String) async throws {

--- a/apps/ios/ExpCore/Sources/API/IntegrationsApi.swift
+++ b/apps/ios/ExpCore/Sources/API/IntegrationsApi.swift
@@ -20,7 +20,8 @@ public final class IntegrationsApi: Sendable {
     }
 
     public func googleStatus(accountId: String) async throws -> GoogleStatusResult {
-        try await trpc.mutation(accountId: accountId, path: "integrations.google.status", input: EmptyIntegrationInput())
+        // Server defines integrations.google.status as a `.query` (GET).
+        try await trpc.query(accountId: accountId, path: "integrations.google.status")
     }
 
     public func googleDisconnect(accountId: String) async throws {

--- a/apps/ios/ExpCore/Sources/API/ProjectsApi.swift
+++ b/apps/ios/ExpCore/Sources/API/ProjectsApi.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+public struct CreateProjectInput: Encodable, Sendable {
+    public let workspaceId: String
+    public let name: String
+    public let prefix: String
+    public var color: String?
+
+    public init(workspaceId: String, name: String, prefix: String, color: String? = nil) {
+        self.workspaceId = workspaceId
+        self.name = name
+        self.prefix = prefix
+        self.color = color
+    }
+}
+
+public struct ProjectResult: Decodable, Sendable {
+    public let project: ProjectResultData
+
+    public init(project: ProjectResultData) {
+        self.project = project
+    }
+}
+
+public struct ProjectResultData: Decodable, Sendable {
+    public let id: String
+
+    public init(id: String) {
+        self.id = id
+    }
+}
+
+public final class ProjectsApi: Sendable {
+    private let trpc: TrpcClient
+
+    public init(trpc: TrpcClient) {
+        self.trpc = trpc
+    }
+
+    /// Create a project. The server uppercases `prefix` and defaults `color`
+    /// to `#6366f1` when omitted. Returns the new project id.
+    public func create(accountId: String, _ input: CreateProjectInput) async throws -> String {
+        let result: ProjectResult = try await trpc.mutation(accountId: accountId, path: "projects.create", input: input)
+        return result.project.id
+    }
+}

--- a/apps/ios/ExpCore/Sources/API/TrpcClient.swift
+++ b/apps/ios/ExpCore/Sources/API/TrpcClient.swift
@@ -56,6 +56,27 @@ public final class TrpcClient: Sendable {
         }
         _ = data
     }
+
+    /// GET an input-less tRPC `query` procedure and decode the same
+    /// `{result:{data}}` envelope `mutation` uses. tRPC routes reads as GET, so
+    /// POSTing to a `.query` returns 405 — use this for those. Mirrors the
+    /// Linux `trpc.query` helper in `apps/linux/src/core/api/trpc.zig`.
+    public func query<O: Decodable>(accountId: String, path: String) async throws -> O {
+        let base = try baseUrl(for: accountId)
+        guard let url = URL(string: "\(base)/api/trpc/\(path)") else {
+            throw TrpcError.invalidUrl
+        }
+
+        let (data, response) = try await httpClient.get(url, accountId: accountId)
+
+        guard (200...299).contains(response.statusCode) else {
+            let text = String(data: data, encoding: .utf8) ?? ""
+            throw TrpcError.httpError(response.statusCode, text)
+        }
+
+        let wrapper = try JSONDecoder().decode(TrpcResponseEnvelope<O>.self, from: data)
+        return wrapper.result.data
+    }
 }
 
 // MARK: - Response Envelope

--- a/apps/ios/ExpCore/Sources/API/WorkspacesApi.swift
+++ b/apps/ios/ExpCore/Sources/API/WorkspacesApi.swift
@@ -20,6 +20,16 @@ public struct WorkspaceResult: Decodable, Sendable {
     }
 }
 
+public struct CreateWorkspaceInput: Encodable, Sendable {
+    public let name: String
+    public var iconUrl: String?
+
+    public init(name: String, iconUrl: String? = nil) {
+        self.name = name
+        self.iconUrl = iconUrl
+    }
+}
+
 public struct UpdateWorkspaceInput: Encodable, Sendable {
     public let id: String
     public var name: String?
@@ -64,6 +74,11 @@ public final class WorkspacesApi: Sendable {
 
     public func ensureDefault(accountId: String) async throws -> WorkspaceResult {
         let result: EnsureDefaultResult = try await trpc.mutation(accountId: accountId, path: "workspaces.ensureDefault", input: EmptyInput())
+        return result.workspace
+    }
+
+    public func create(accountId: String, name: String, iconUrl: String? = nil) async throws -> WorkspaceResult {
+        let result: EnsureDefaultResult = try await trpc.mutation(accountId: accountId, path: "workspaces.create", input: CreateWorkspaceInput(name: name, iconUrl: iconUrl))
         return result.workspace
     }
 

--- a/apps/ios/ExpUI/Sources/ColorHex.swift
+++ b/apps/ios/ExpUI/Sources/ColorHex.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+extension Color {
+    /// Best-effort `#rrggbb` parsing for project/label accent colors. Accepts an
+    /// optional string (project/label colors can be nil) and tolerates a leading
+    /// `#` plus surrounding whitespace; returns nil for anything that isn't a
+    /// 6-digit hex so callers can fall back (`Color(hex:) ?? .gray`).
+    public init?(hex: String?) {
+        guard let hex else { return nil }
+        let cleaned = hex
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "#", with: "")
+        guard cleaned.count == 6, let rgb = UInt64(cleaned, radix: 16) else { return nil }
+        self.init(
+            red: Double((rgb >> 16) & 0xFF) / 255.0,
+            green: Double((rgb >> 8) & 0xFF) / 255.0,
+            blue: Double(rgb & 0xFF) / 255.0
+        )
+    }
+}

--- a/apps/ios/ExpUI/Sources/ColorSwatchGrid.swift
+++ b/apps/ios/ExpUI/Sources/ColorSwatchGrid.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+/// Canonical label/project color palette — identical to the web app's
+/// `apps/web/src/lib/label-colors.ts` so the three clients pick from the same set.
+public let LABEL_COLORS: [String] = [
+    "#ef4444", "#dc2626", "#f97316", "#f59e0b", "#eab308",
+    "#84cc16", "#22c55e", "#10b981", "#14b8a6", "#06b6d4",
+    "#0ea5e9", "#3b82f6", "#6366f1", "#8b5cf6", "#a855f7",
+    "#ec4899", "#f43f5e", "#78716c", "#64748b", "#a3a3a3",
+]
+
+/// Default color the server applies to new labels/projects when none is chosen.
+public let DEFAULT_LABEL_COLOR = "#6366f1"
+
+/// A tap-to-select swatch grid bound to a hex string. Shared by the iOS and
+/// macOS label/project color pickers (ports the iOS `WorkspaceLabelsSection`
+/// palette so both platforms stay in sync).
+public struct ColorSwatchGrid: View {
+    @Binding var selection: String
+    let colors: [String]
+    let swatchSize: CGFloat
+
+    public init(selection: Binding<String>, colors: [String] = LABEL_COLORS, swatchSize: CGFloat = 22) {
+        self._selection = selection
+        self.colors = colors
+        self.swatchSize = swatchSize
+    }
+
+    public var body: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: swatchSize + 6), spacing: 6)], spacing: 6) {
+            ForEach(colors, id: \.self) { color in
+                Button {
+                    selection = color
+                } label: {
+                    Circle()
+                        .fill(Color(hex: color) ?? .gray)
+                        .frame(width: swatchSize, height: swatchSize)
+                        .overlay(
+                            Circle().stroke(Color.white, lineWidth: selection == color ? 2 : 0)
+                        )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}

--- a/apps/ios/ExpUI/Sources/GlassTheme.swift
+++ b/apps/ios/ExpUI/Sources/GlassTheme.swift
@@ -131,11 +131,20 @@ public enum TextOpacity {
     public static let quaternary: Double = 0.3
 }
 
+// MARK: - Accent
+
+public enum Accent {
+    /// The web app's primary indigo (#6366f1) — used for primary buttons,
+    /// count badges, and selection accents. Replaces system blue.
+    public static let indigo = Color(red: 0.388, green: 0.400, blue: 0.945)
+}
+
 // MARK: - Status Colors
 
 public enum StatusColor {
     public static let backlog = Color.gray
-    public static let todo = Color.gray
+    /// Web's todo is `text-foreground` (near-white), not gray.
+    public static let todo = Zinc._50
     public static let inProgress = Color.yellow
     public static let done = Color.green
     public static let cancelled = Color.red

--- a/apps/ios/ExpUI/Sources/WorkspaceAvatar.swift
+++ b/apps/ios/ExpUI/Sources/WorkspaceAvatar.swift
@@ -36,6 +36,6 @@ public struct WorkspaceAvatar: View {
             .font(.caption.weight(.bold))
             .foregroundStyle(.white)
             .frame(width: size, height: size)
-            .background(Color.blue.opacity(0.6))
+            .background(Accent.indigo.opacity(0.6))
     }
 }

--- a/apps/ios/Exponential/UI/Issue/IssueListView.swift
+++ b/apps/ios/Exponential/UI/Issue/IssueListView.swift
@@ -329,16 +329,3 @@ struct IssueListView: View {
     }
 }
 
-// MARK: - Color from hex
-
-extension Color {
-    init?(hex: String) {
-        let cleaned = hex.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: "#", with: "")
-        guard cleaned.count == 6, let rgb = UInt64(cleaned, radix: 16) else { return nil }
-        self.init(
-            red: Double((rgb >> 16) & 0xFF) / 255.0,
-            green: Double((rgb >> 8) & 0xFF) / 255.0,
-            blue: Double(rgb & 0xFF) / 255.0
-        )
-    }
-}

--- a/apps/ios/Exponential/UI/Settings/WorkspaceMembersSection.swift
+++ b/apps/ios/Exponential/UI/Settings/WorkspaceMembersSection.swift
@@ -16,6 +16,11 @@ struct WorkspaceMembersSection: View {
     @State private var copied = false
     @State private var generating = false
 
+    // A workspace must always keep at least one owner.
+    private var ownerCount: Int {
+        members.filter { $0.role == DomainContract.workspaceRoleOwner }.count
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
@@ -66,6 +71,8 @@ struct WorkspaceMembersSection: View {
                         .glassButton()
 
                     // Actions menu
+                    let isSelf = member.userId == currentUserId
+                    let isLastOwner = member.role == DomainContract.workspaceRoleOwner && ownerCount <= 1
                     Menu {
                         if member.role != DomainContract.workspaceRoleOwner {
                             Button {
@@ -80,11 +87,22 @@ struct WorkspaceMembersSection: View {
                             } label: {
                                 Label("Make member", systemImage: "shield")
                             }
+                            .disabled(isLastOwner)
                         }
-                        Button(role: .destructive) {
-                            Task { try? await membersApi.remove(accountId: accountId, memberId: member.id) }
-                        } label: {
-                            Label(member.userId == currentUserId ? "Leave" : "Remove", systemImage: "xmark")
+                        if isSelf {
+                            if !isLastOwner {
+                                Button(role: .destructive) {
+                                    Task { try? await membersApi.remove(accountId: accountId, memberId: member.id) }
+                                } label: {
+                                    Label("Leave", systemImage: "xmark")
+                                }
+                            }
+                        } else {
+                            Button(role: .destructive) {
+                                Task { try? await membersApi.remove(accountId: accountId, memberId: member.id) }
+                            } label: {
+                                Label("Remove", systemImage: "xmark")
+                            }
                         }
                     } label: {
                         Image(systemName: "ellipsis")

--- a/apps/ios/ExponentialMac/MacAdminView.swift
+++ b/apps/ios/ExponentialMac/MacAdminView.swift
@@ -1,0 +1,213 @@
+import ExpCore
+import ExpUI
+import SwiftUI
+
+/// Admin panel mirroring the iOS `AdminUsersView` / `AdminWorkspacesView`,
+/// adapted to macOS chrome (a sheet with a segmented Users/Workspaces switch
+/// instead of a `NavigationStack` push). Owner gates this behind
+/// `deps.auth.isAdmin` in the shell footer menu.
+struct MacAdminView: View {
+    @Environment(MacAppDependencies.self) private var deps
+    @Environment(\.dismiss) private var dismiss
+    let accountId: String
+
+    private enum Tab: String, CaseIterable, Identifiable {
+        case users = "Users"
+        case workspaces = "Workspaces"
+        var id: String { rawValue }
+    }
+
+    @State private var tab: Tab = .users
+
+    @State private var users: [AdminUser] = []
+    @State private var workspaces: [AdminWorkspace] = []
+    @State private var loading = true
+    @State private var error: String?
+    @State private var userSearch = ""
+    @State private var workspaceSearch = ""
+    @State private var deleteUserTarget: AdminUser?
+    @State private var deleteWorkspaceTarget: AdminWorkspace?
+
+    private var filteredUsers: [AdminUser] {
+        guard !userSearch.isEmpty else { return users }
+        let q = userSearch.lowercased()
+        return users.filter { ($0.name?.lowercased().contains(q) ?? false) || $0.email.lowercased().contains(q) }
+    }
+
+    private var filteredWorkspaces: [AdminWorkspace] {
+        guard !workspaceSearch.isEmpty else { return workspaces }
+        let q = workspaceSearch.lowercased()
+        return workspaces.filter { $0.name.lowercased().contains(q) || $0.slug.lowercased().contains(q) }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Admin").font(.headline)
+                Spacer()
+                Button("Done") { dismiss() }
+            }
+            .padding()
+            Divider()
+
+            Picker("", selection: $tab) {
+                ForEach(Tab.allCases) { Text($0.rawValue).tag($0) }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .padding(12)
+
+            if loading {
+                ProgressView().frame(maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 8) {
+                        switch tab {
+                        case .users:
+                            TextField("Search by name or email…", text: $userSearch)
+                                .textFieldStyle(.roundedBorder)
+                            ForEach(filteredUsers) { userRow($0) }
+                        case .workspaces:
+                            TextField("Search by name or slug…", text: $workspaceSearch)
+                                .textFieldStyle(.roundedBorder)
+                            ForEach(filteredWorkspaces) { workspaceRow($0) }
+                        }
+                    }
+                    .padding(16)
+                }
+                if let error {
+                    Text(error).font(.caption).foregroundStyle(.red).padding(.bottom, 8)
+                }
+            }
+        }
+        .frame(width: 640, height: 620)
+        .task { await load() }
+        .confirmationDialog(
+            "Delete \(deleteUserTarget?.email ?? "")?",
+            isPresented: Binding(get: { deleteUserTarget != nil }, set: { if !$0 { deleteUserTarget = nil } }),
+            titleVisibility: .visible
+        ) {
+            Button("Delete user", role: .destructive) {
+                if let t = deleteUserTarget {
+                    Task { try? await deps.adminApi.deleteUser(accountId: accountId, userId: t.id); await load() }
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        }
+        .confirmationDialog(
+            "Delete workspace \(deleteWorkspaceTarget?.name ?? "")?",
+            isPresented: Binding(get: { deleteWorkspaceTarget != nil }, set: { if !$0 { deleteWorkspaceTarget = nil } }),
+            titleVisibility: .visible
+        ) {
+            Button("Delete workspace", role: .destructive) {
+                if let t = deleteWorkspaceTarget {
+                    Task { try? await deps.adminApi.deleteWorkspace(accountId: accountId, workspaceId: t.id); await load() }
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This will permanently delete the workspace and all its data.")
+        }
+    }
+
+    private func userRow(_ user: AdminUser) -> some View {
+        HStack(spacing: 12) {
+            Text((user.name ?? user.email).prefix(1).uppercased())
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.white)
+                .frame(width: 32, height: 32)
+                .background(Color.white.opacity(0.15))
+                .clipShape(Circle())
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 4) {
+                    Text(user.name ?? "No name").font(.subheadline)
+                    if user.id == deps.auth.userId {
+                        Text("(you)").font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                Text(user.email).font(.caption).foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Toggle("", isOn: Binding(
+                get: { user.isAdmin },
+                set: { newValue in
+                    Task {
+                        try? await deps.adminApi.setUserAdmin(accountId: accountId, userId: user.id, isAdmin: newValue)
+                        await load()
+                    }
+                }
+            ))
+            .labelsHidden()
+            .tint(Accent.indigo)
+
+            Menu {
+                Button(role: .destructive) { deleteUserTarget = user } label: {
+                    Label("Delete user", systemImage: "trash")
+                }
+            } label: {
+                Image(systemName: "ellipsis").foregroundStyle(.secondary)
+            }
+            .menuStyle(.borderlessButton).fixedSize()
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .glassRow()
+    }
+
+    private func workspaceRow(_ workspace: AdminWorkspace) -> some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(workspace.name).font(.subheadline)
+                Text(workspace.slug).font(.caption).foregroundStyle(.secondary)
+            }
+
+            if let plan = workspace.plan, !plan.isEmpty {
+                Text(plan.capitalized)
+                    .font(.caption2.weight(.medium))
+                    .padding(.horizontal, 6).padding(.vertical, 2)
+                    .background(Color.white.opacity(0.1))
+                    .clipShape(Capsule())
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            HStack(spacing: 12) {
+                Label("\(workspace.memberCount ?? 0)", systemImage: "person.2")
+                Label("\(workspace.projectCount ?? 0)", systemImage: "folder")
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            Menu {
+                Button(role: .destructive) { deleteWorkspaceTarget = workspace } label: {
+                    Label("Delete workspace", systemImage: "trash")
+                }
+            } label: {
+                Image(systemName: "ellipsis").foregroundStyle(.secondary)
+            }
+            .menuStyle(.borderlessButton).fixedSize()
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .glassRow()
+    }
+
+    private func load() async {
+        do {
+            async let u = deps.adminApi.listUsers(accountId: accountId)
+            async let w = deps.adminApi.listWorkspaces(accountId: accountId)
+            users = try await u.filter {
+                !($0.email.hasPrefix("agent-") && $0.email.hasSuffix("@exponential.local"))
+            }
+            workspaces = try await w
+            loading = false
+        } catch {
+            self.error = error.localizedDescription
+            loading = false
+        }
+    }
+}

--- a/apps/ios/ExponentialMac/MacAppDependencies.swift
+++ b/apps/ios/ExponentialMac/MacAppDependencies.swift
@@ -22,10 +22,13 @@ final class MacAppDependencies: @unchecked Sendable {
     let labelsApi: LabelsApi
     let commentsApi: CommentsApi
     let workspacesApi: WorkspacesApi
+    let projectsApi: ProjectsApi
     let workspaceMembersApi: WorkspaceMembersApi
     let workspaceInvitesApi: WorkspaceInvitesApi
     let issueImagesApi: IssueImagesApi
     let agentPlanApi: AgentPlanApi
+    let adminApi: AdminApi
+    let integrationsApi: IntegrationsApi
     let agentService: MacAgentService
 
     init() {
@@ -67,10 +70,13 @@ final class MacAppDependencies: @unchecked Sendable {
         self.labelsApi = LabelsApi(trpc: trpc)
         self.commentsApi = CommentsApi(trpc: trpc)
         self.workspacesApi = WorkspacesApi(trpc: trpc)
+        self.projectsApi = ProjectsApi(trpc: trpc)
         self.workspaceMembersApi = WorkspaceMembersApi(trpc: trpc)
         self.workspaceInvitesApi = WorkspaceInvitesApi(trpc: trpc)
         self.issueImagesApi = IssueImagesApi(httpClient: httpClient, auth: auth)
         self.agentPlanApi = AgentPlanApi(trpc: trpc)
+        self.adminApi = AdminApi(trpc: trpc)
+        self.integrationsApi = IntegrationsApi(trpc: trpc)
         // @State initializes this composition root on the main actor, so it's safe
         // to construct the MainActor-isolated agent service here (it starts
         // heartbeats for any already-registered workspaces).

--- a/apps/ios/ExponentialMac/MacCreateIssueView.swift
+++ b/apps/ios/ExponentialMac/MacCreateIssueView.swift
@@ -8,6 +8,8 @@ struct MacCreateIssueView: View {
     let accountId: String
     let projectId: String
     let users: [UserEntity]
+    var labels: [LabelEntity] = []
+    var initialStatus: IssueStatus = .backlog
     var onCreated: () -> Void = {}
 
     @State private var title = ""
@@ -16,11 +18,23 @@ struct MacCreateIssueView: View {
     @State private var assigneeId: String?
     @State private var hasDueDate = false
     @State private var dueDate = Date()
+    @State private var dueTime: String?
+    @State private var endTime: String?
+    @State private var recurrenceInterval: Int?
+    @State private var recurrenceUnit: RecurrenceUnit?
+    @State private var selectedLabelIds: Set<String> = []
+    @State private var createMore = false
+    @State private var showLabelPicker = false
     @State private var editor = IssueEditorModel()
+    @State private var seeded = false
     @State private var loading = false
     @State private var error: String?
 
     private var baseURL: URL? { deps.auth.instanceBaseURL(forAccountId: accountId) }
+
+    private var selectedLabels: [LabelEntity] {
+        labels.filter { selectedLabelIds.contains($0.id) }.sorted { $0.name < $1.name }
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -42,9 +56,50 @@ struct MacCreateIssueView: View {
                 ForEach(users) { Text($0.name ?? $0.email).tag(String?.some($0.id)) }
             }
 
+            // Labels
+            HStack(spacing: 8) {
+                Text("Labels").frame(width: 64, alignment: .leading).foregroundStyle(.secondary)
+                Button { showLabelPicker = true } label: { Label("Add", systemImage: "tag") }
+                    .buttonStyle(.borderless)
+                    .disabled(labels.isEmpty)
+                    .popover(isPresented: $showLabelPicker, arrowEdge: .bottom) { labelPicker }
+                ForEach(selectedLabels) { label in
+                    HStack(spacing: 4) {
+                        Circle().fill(Color(hex: label.color) ?? .gray).frame(width: 8, height: 8)
+                        Text(label.name).font(.caption)
+                    }
+                    .padding(.horizontal, 8).padding(.vertical, 3)
+                    .glassButton()
+                }
+                Spacer(minLength: 0)
+            }
+
+            // Recurrence
+            HStack(spacing: 8) {
+                Text("Repeat").frame(width: 64, alignment: .leading).foregroundStyle(.secondary)
+                MacRecurrenceMenu(interval: recurrenceInterval, unit: recurrenceUnit?.rawValue) { interval, unit in
+                    recurrenceInterval = interval
+                    recurrenceUnit = unit
+                }
+                Spacer()
+            }
+
+            // Due date + optional start/end times
             Toggle("Set due date", isOn: $hasDueDate)
             if hasDueDate {
                 DatePicker("Due", selection: $dueDate, displayedComponents: [.date]).labelsHidden()
+                HStack(spacing: 16) {
+                    HStack(spacing: 6) {
+                        Text("Start").foregroundStyle(.secondary)
+                        MacTimeFieldButton(value: dueTime) { dueTime = $0 }
+                    }
+                    HStack(spacing: 6) {
+                        Text("End").foregroundStyle(.secondary)
+                        MacTimeFieldButton(value: endTime) { endTime = $0 }
+                    }
+                    Spacer()
+                }
+                .font(.subheadline)
             }
 
             Text("Description").font(.caption).foregroundStyle(.secondary)
@@ -54,6 +109,7 @@ struct MacCreateIssueView: View {
             if let error { Text(error).foregroundStyle(.red).font(.callout) }
 
             HStack {
+                Toggle("Create more", isOn: $createMore)
                 Spacer()
                 Button("Cancel") { dismiss() }
                 Button("Create") { Task { await create() } }
@@ -63,7 +119,33 @@ struct MacCreateIssueView: View {
             }
         }
         .padding(20)
-        .frame(width: 520)
+        .frame(width: 540)
+        .onAppear { if !seeded { status = initialStatus; seeded = true } }
+    }
+
+    @ViewBuilder
+    private var labelPicker: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(labels.sorted { $0.name < $1.name }) { label in
+                Button {
+                    if selectedLabelIds.contains(label.id) { selectedLabelIds.remove(label.id) }
+                    else { selectedLabelIds.insert(label.id) }
+                } label: {
+                    HStack(spacing: 8) {
+                        Circle().fill(Color(hex: label.color) ?? .gray).frame(width: 9, height: 9)
+                        Text(label.name)
+                        Spacer()
+                        if selectedLabelIds.contains(label.id) {
+                            Image(systemName: "checkmark").foregroundStyle(.tint)
+                        }
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(12)
+        .frame(width: 220)
     }
 
     private func create() async {
@@ -90,7 +172,12 @@ struct MacCreateIssueView: View {
             priority: priority.rawValue,
             assigneeId: assigneeId,
             description: stripped.isEmpty ? nil : IssueDescription(text: stripped),
-            dueDate: dateStr
+            dueDate: dateStr,
+            dueTime: dateStr == nil ? nil : dueTime,
+            endTime: dateStr == nil ? nil : endTime,
+            labelIds: selectedLabelIds.isEmpty ? nil : Array(selectedLabelIds),
+            recurrenceInterval: recurrenceInterval,
+            recurrenceUnit: recurrenceUnit?.rawValue
         )
         do {
             let createdId = try await deps.issuesApi.create(accountId: accountId, input)
@@ -114,7 +201,14 @@ struct MacCreateIssueView: View {
                 }
             }
             onCreated()
-            dismiss()
+            if createMore {
+                // Keep the sheet open and reset the per-issue fields (mirrors iOS).
+                title = ""
+                editor = IssueEditorModel()
+                selectedLabelIds = []
+            } else {
+                dismiss()
+            }
         } catch {
             self.error = error.localizedDescription
         }

--- a/apps/ios/ExponentialMac/MacCreateIssueView.swift
+++ b/apps/ios/ExponentialMac/MacCreateIssueView.swift
@@ -202,10 +202,11 @@ struct MacCreateIssueView: View {
             }
             onCreated()
             if createMore {
-                // Keep the sheet open and reset the per-issue fields (mirrors iOS).
+                // Keep the sheet open and reset only the title + description, leaving
+                // the chosen status/priority/assignee/labels/due/recurrence in place so
+                // a batch of similar issues is quick to file (mirrors iOS CreateIssueSheet).
                 title = ""
                 editor = IssueEditorModel()
-                selectedLabelIds = []
             } else {
                 dismiss()
             }

--- a/apps/ios/ExponentialMac/MacCreateIssueView.swift
+++ b/apps/ios/ExponentialMac/MacCreateIssueView.swift
@@ -103,8 +103,10 @@ struct MacCreateIssueView: View {
             }
 
             Text("Description").font(.caption).foregroundStyle(.secondary)
+            // Top-align so the toolbar sits directly under the label (the default
+            // .center left an empty band above it), and grow from a compact height.
             MacMarkdownEditor(model: editor, baseURL: baseURL, accountId: accountId, httpClient: deps.httpClient)
-                .frame(minHeight: 160, maxHeight: 360)
+                .frame(minHeight: 120, maxHeight: 320, alignment: .top)
 
             if let error { Text(error).foregroundStyle(.red).font(.callout) }
 

--- a/apps/ios/ExponentialMac/MacCreateIssueView.swift
+++ b/apps/ios/ExponentialMac/MacCreateIssueView.swift
@@ -58,6 +58,7 @@ struct MacCreateIssueView: View {
                 Button("Cancel") { dismiss() }
                 Button("Create") { Task { await create() } }
                     .buttonStyle(.borderedProminent)
+                    .tint(Accent.indigo)
                     .disabled(loading || title.trimmingCharacters(in: .whitespaces).isEmpty)
             }
         }

--- a/apps/ios/ExponentialMac/MacCreateProjectView.swift
+++ b/apps/ios/ExponentialMac/MacCreateProjectView.swift
@@ -1,0 +1,73 @@
+import ExpCore
+import ExpUI
+import SwiftUI
+
+/// Create a project in the given workspace (no iOS sibling — projects are
+/// created on web today). Opened from the sidebar "+" in MacShell.
+struct MacCreateProjectView: View {
+    @Environment(MacAppDependencies.self) private var deps
+    @Environment(\.dismiss) private var dismiss
+    let accountId: String
+    let workspaceId: String
+    var onCreated: (String) -> Void = { _ in }
+
+    @State private var name = ""
+    @State private var prefix = ""
+    @State private var prefixEdited = false
+    @State private var color = DEFAULT_LABEL_COLOR
+    @State private var loading = false
+    @State private var error: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("New Project").font(.title3.weight(.semibold))
+
+            TextField("Name", text: $name)
+                .textFieldStyle(.roundedBorder)
+                .onChange(of: name) { _, newValue in
+                    // Auto-suggest a prefix from the name until the user edits it.
+                    if !prefixEdited {
+                        prefix = String(newValue.filter(\.isLetter).prefix(3)).uppercased()
+                    }
+                }
+
+            TextField("Prefix (e.g. ENG)", text: $prefix)
+                .textFieldStyle(.roundedBorder)
+                .onChange(of: prefix) { _, _ in prefixEdited = true }
+
+            Text("Color").font(.caption).foregroundStyle(.secondary)
+            ColorSwatchGrid(selection: $color)
+
+            if let error { Text(error).foregroundStyle(.red).font(.callout) }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                Button("Create") { Task { await create() } }
+                    .buttonStyle(.borderedProminent)
+                    .tint(Accent.indigo)
+                    .disabled(loading || name.trimmingCharacters(in: .whitespaces).isEmpty || prefix.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+        }
+        .padding(20)
+        .frame(width: 420)
+    }
+
+    private func create() async {
+        loading = true
+        error = nil
+        do {
+            let id = try await deps.projectsApi.create(accountId: accountId, CreateProjectInput(
+                workspaceId: workspaceId,
+                name: name.trimmingCharacters(in: .whitespaces),
+                prefix: prefix.trimmingCharacters(in: .whitespaces),
+                color: color
+            ))
+            onCreated(id)
+            dismiss()
+        } catch {
+            self.error = error.localizedDescription
+        }
+        loading = false
+    }
+}

--- a/apps/ios/ExponentialMac/MacCreateWorkspaceView.swift
+++ b/apps/ios/ExponentialMac/MacCreateWorkspaceView.swift
@@ -1,0 +1,50 @@
+import ExpCore
+import ExpUI
+import SwiftUI
+
+/// Create a workspace on the given account. Opened from the workspace switcher
+/// "New workspace" entry in MacShell.
+struct MacCreateWorkspaceView: View {
+    @Environment(MacAppDependencies.self) private var deps
+    @Environment(\.dismiss) private var dismiss
+    let accountId: String
+    var onCreated: (String) -> Void = { _ in }
+
+    @State private var name = ""
+    @State private var loading = false
+    @State private var error: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("New Workspace").font(.title3.weight(.semibold))
+
+            TextField("Name", text: $name).textFieldStyle(.roundedBorder)
+
+            if let error { Text(error).foregroundStyle(.red).font(.callout) }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                Button("Create") { Task { await create() } }
+                    .buttonStyle(.borderedProminent)
+                    .tint(Accent.indigo)
+                    .disabled(loading || name.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+        }
+        .padding(20)
+        .frame(width: 380)
+    }
+
+    private func create() async {
+        loading = true
+        error = nil
+        do {
+            let workspace = try await deps.workspacesApi.create(accountId: accountId, name: name.trimmingCharacters(in: .whitespaces))
+            onCreated(workspace.id)
+            dismiss()
+        } catch {
+            self.error = error.localizedDescription
+        }
+        loading = false
+    }
+}

--- a/apps/ios/ExponentialMac/MacIntegrationsView.swift
+++ b/apps/ios/ExponentialMac/MacIntegrationsView.swift
@@ -1,0 +1,115 @@
+import ExpCore
+import ExpUI
+import SwiftUI
+
+/// Integrations panel mirroring the iOS `IntegrationsView`, adapted to a macOS
+/// sheet. Google Calendar status + Backfill + Disconnect; "Connect" opens the
+/// web integrations page (the OAuth link flow stays web-only, matching iOS).
+struct MacIntegrationsView: View {
+    @Environment(MacAppDependencies.self) private var deps
+    @Environment(\.dismiss) private var dismiss
+    let accountId: String
+
+    @State private var googleConnected = false
+    @State private var googleConnectedAt: String?
+    @State private var loading = true
+    @State private var error: String?
+    @State private var backfilling = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Integrations").font(.headline)
+                Spacer()
+                Button("Done") { dismiss() }
+            }
+            .padding()
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack(spacing: 10) {
+                        Image(systemName: "calendar").font(.title2)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Google Calendar").font(.body.weight(.medium))
+                            Text("Sync issue due dates as calendar events")
+                                .font(.caption).foregroundStyle(.secondary)
+                        }
+                    }
+
+                    if loading {
+                        ProgressView()
+                    } else if googleConnected {
+                        HStack(spacing: 6) {
+                            Circle().fill(.green).frame(width: 8, height: 8)
+                            Text("Connected").font(.caption).foregroundStyle(.green)
+                            if let at = googleConnectedAt {
+                                Text("since \(at.prefix(10))").font(.caption).foregroundStyle(.secondary)
+                            }
+                        }
+                        HStack(spacing: 10) {
+                            Button { Task { await backfill() } } label: {
+                                HStack(spacing: 4) {
+                                    if backfilling { ProgressView().controlSize(.small) }
+                                    Text("Backfill")
+                                }
+                            }
+                            .disabled(backfilling)
+
+                            Button(role: .destructive) { Task { await disconnect() } } label: {
+                                Text("Disconnect")
+                            }
+                        }
+                    } else {
+                        Text("Not connected").font(.caption).foregroundStyle(.secondary)
+                        Button("Connect…") {
+                            if let base = deps.auth.instanceUrl, let url = URL(string: "\(base)/account/integrations") {
+                                Platform.open(url)
+                            }
+                        }
+                    }
+
+                    if let error {
+                        Text(error).font(.caption).foregroundStyle(.red)
+                    }
+                }
+                .padding(16)
+                .glassSection()
+                .padding(16)
+            }
+        }
+        .frame(width: 520, height: 360)
+        .task { await loadStatus() }
+    }
+
+    private func loadStatus() async {
+        do {
+            let status = try await deps.integrationsApi.googleStatus(accountId: accountId)
+            googleConnected = status.connected
+            googleConnectedAt = status.connectedAt
+            loading = false
+        } catch {
+            self.error = error.localizedDescription
+            loading = false
+        }
+    }
+
+    private func disconnect() async {
+        do {
+            try await deps.integrationsApi.googleDisconnect(accountId: accountId)
+            googleConnected = false
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    private func backfill() async {
+        backfilling = true
+        do {
+            try await deps.integrationsApi.googleBackfill(accountId: accountId)
+        } catch {
+            self.error = error.localizedDescription
+        }
+        backfilling = false
+    }
+}

--- a/apps/ios/ExponentialMac/MacIssueControls.swift
+++ b/apps/ios/ExponentialMac/MacIssueControls.swift
@@ -1,0 +1,170 @@
+import ExpCore
+import ExpUI
+import SwiftUI
+
+// Shared issue-property controls for the macOS create + detail surfaces.
+// Mirrors the iOS TimeFieldButton / RecurrencePickerSheet / formatRecurrence,
+// substituting macOS-native chrome (Menu + Popover) for the iOS bottom sheets
+// and wheel picker (`.wheel` doesn't exist on macOS).
+
+/// "HH:mm" wire format for dueTime/endTime. The iOS app uses the shared
+/// `AppDateFormatters`, which lives in the iOS target only — the Mac target
+/// keeps its own equivalent.
+let macHHmmFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.dateFormat = "HH:mm"
+    f.locale = Locale(identifier: "en_US_POSIX")
+    return f
+}()
+
+/// Same wording as the iOS `formatRecurrence` (Daily/Weekly/Monthly for
+/// interval == 1, else "Every N units").
+func formatRecurrence(_ interval: Int?, _ unit: String?) -> String {
+    guard let interval, let unitRaw = unit, let unit = RecurrenceUnit(rawValue: unitRaw) else {
+        return "Doesn't repeat"
+    }
+    if interval == 1 {
+        switch unit {
+        case .day: return "Daily"
+        case .week: return "Weekly"
+        case .month: return "Monthly"
+        }
+    }
+    return "Every \(interval) \(unit.label(for: interval))"
+}
+
+/// Short relative time ("2h ago") from an ISO-8601 timestamp. Ports the iOS
+/// CommentThreadView helper.
+func macRelativeDate(_ s: String) -> String {
+    let iso = ISO8601DateFormatter()
+    iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    let date = iso.date(from: s) ?? ISO8601DateFormatter().date(from: s)
+    guard let date else { return "" }
+    let f = RelativeDateTimeFormatter()
+    f.unitsStyle = .short
+    return f.localizedString(for: date, relativeTo: Date())
+}
+
+/// Nullable "HH:mm" time field — a popover with an hour/minute picker and a
+/// Clear affordance. The iOS sibling uses `.datePickerStyle(.wheel)`, which is
+/// unavailable on macOS, so this uses the default stepper field.
+struct MacTimeFieldButton: View {
+    let value: String?
+    var placeholder: String = "—"
+    let onChange: (String?) -> Void
+
+    @State private var showPicker = false
+    @State private var draft = Date()
+
+    var body: some View {
+        Button {
+            draft = parseTime(value) ?? defaultTime()
+            showPicker = true
+        } label: {
+            Text(value ?? placeholder)
+                .font(.subheadline.monospacedDigit())
+                .foregroundStyle(value == nil ? Color.secondary : Color.primary)
+        }
+        .buttonStyle(.borderless)
+        .fixedSize()
+        .popover(isPresented: $showPicker, arrowEdge: .bottom) {
+            VStack(spacing: 12) {
+                DatePicker("Time", selection: $draft, displayedComponents: [.hourAndMinute])
+                    .datePickerStyle(.stepperField)
+                    .labelsHidden()
+                HStack {
+                    if value != nil {
+                        Button("Clear", role: .destructive) { onChange(nil); showPicker = false }
+                    }
+                    Spacer()
+                    Button("Cancel") { showPicker = false }
+                    Button("Save") { onChange(macHHmmFormatter.string(from: draft)); showPicker = false }
+                        .buttonStyle(.borderedProminent)
+                        .tint(Accent.indigo)
+                }
+            }
+            .padding(16)
+            .frame(width: 240)
+        }
+    }
+
+    private func parseTime(_ value: String?) -> Date? {
+        guard let value else { return nil }
+        return macHHmmFormatter.date(from: value)
+    }
+
+    private func defaultTime() -> Date {
+        var c = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+        c.hour = 9
+        c.minute = 0
+        return Calendar.current.date(from: c) ?? Date()
+    }
+}
+
+/// Wrapping flow layout for label chips (ports the iOS `FlowLayout`, which
+/// lives in the iOS target).
+struct MacFlowLayout: Layout {
+    var spacing: CGFloat = 6
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        arrange(proposal: proposal, subviews: subviews).size
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let result = arrange(proposal: proposal, subviews: subviews)
+        for (index, position) in result.positions.enumerated() {
+            subviews[index].place(at: CGPoint(x: bounds.minX + position.x, y: bounds.minY + position.y), proposal: .unspecified)
+        }
+    }
+
+    private func arrange(proposal: ProposedViewSize, subviews: Subviews) -> (positions: [CGPoint], size: CGSize) {
+        let maxWidth = proposal.width ?? .infinity
+        var positions: [CGPoint] = []
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        var maxX: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x + size.width > maxWidth && x > 0 {
+                x = 0
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            positions.append(CGPoint(x: x, y: y))
+            rowHeight = max(rowHeight, size.height)
+            x += size.width + spacing
+            maxX = max(maxX, x)
+        }
+        return (positions, CGSize(width: maxX, height: y + rowHeight))
+    }
+}
+
+/// Recurrence picker as a macOS `Menu` with one submenu per `RecurrenceUnit`
+/// (interval and unit always commit together, matching the server's
+/// assertRecurrencePair). "Doesn't repeat" clears both.
+struct MacRecurrenceMenu: View {
+    let interval: Int?
+    let unit: String?
+    let onSelect: (Int?, RecurrenceUnit?) -> Void
+    var enabled: Bool = true
+
+    var body: some View {
+        Menu {
+            Button("Doesn't repeat") { onSelect(nil, nil) }
+            ForEach(RecurrenceUnit.allCases) { u in
+                Menu(u.label(for: 2).capitalized) {
+                    ForEach(DomainContract.recurrenceIntervals, id: \.self) { n in
+                        Button("Every \(n) \(u.label(for: n))") { onSelect(n, u) }
+                    }
+                }
+            }
+        } label: {
+            Label(formatRecurrence(interval, unit), systemImage: "repeat")
+                .foregroundStyle(interval == nil ? Color.secondary : Color.primary)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .disabled(!enabled)
+    }
+}

--- a/apps/ios/ExponentialMac/MacIssueDetailView.swift
+++ b/apps/ios/ExponentialMac/MacIssueDetailView.swift
@@ -116,14 +116,18 @@ final class MacIssueDetailModel {
 
     private func resolvePermissions(for issue: IssueEntity) {
         guard let pool = try? deps.db.pool(forAccountId: accountId) else { return }
-        let project = (try? pool.read { db in try ProjectEntity.fetchOne(db, key: issue.projectId) }) ?? nil
-        projectName = project?.name
-        let workspace: WorkspaceEntity? = project.flatMap { p in
-            (try? pool.read { db in try WorkspaceEntity.fetchOne(db, key: p.workspaceId) }) ?? nil
+        // Fetch project + workspace in a single read so they stay consistent if a
+        // concurrent sync deletes the project mid-resolution.
+        let resolved = try? pool.read { db -> (ProjectEntity?, WorkspaceEntity?) in
+            let project = try ProjectEntity.fetchOne(db, key: issue.projectId)
+            let workspace = try project.flatMap { try WorkspaceEntity.fetchOne(db, key: $0.workspaceId) }
+            return (project, workspace)
         }
+        projectName = resolved?.0?.name
+        let workspace = resolved?.1
         workspaceId = workspace?.id
         permissions = WorkspacePermissions.resolve(
-            workspace: workspace ?? nil,
+            workspace: workspace,
             currentUserId: deps.auth.userId,
             isAdmin: deps.auth.isAdmin,
             dbPool: pool

--- a/apps/ios/ExponentialMac/MacIssueDetailView.swift
+++ b/apps/ios/ExponentialMac/MacIssueDetailView.swift
@@ -18,6 +18,7 @@ final class MacIssueDetailModel {
     var attachments: [AttachmentEntity] = []
     var permissions: WorkspacePermissions?
     var workspaceId: String?
+    var projectName: String?
     var error: String?
 
     // Title is a local buffer (seeded once so live sync doesn't clobber typing);
@@ -115,9 +116,10 @@ final class MacIssueDetailModel {
 
     private func resolvePermissions(for issue: IssueEntity) {
         guard let pool = try? deps.db.pool(forAccountId: accountId) else { return }
-        let workspace = try? pool.read { db -> WorkspaceEntity? in
-            guard let project = try ProjectEntity.fetchOne(db, key: issue.projectId) else { return nil }
-            return try WorkspaceEntity.fetchOne(db, key: project.workspaceId)
+        let project = (try? pool.read { db in try ProjectEntity.fetchOne(db, key: issue.projectId) }) ?? nil
+        projectName = project?.name
+        let workspace: WorkspaceEntity? = project.flatMap { p in
+            (try? pool.read { db in try WorkspaceEntity.fetchOne(db, key: p.workspaceId) }) ?? nil
         }
         workspaceId = workspace?.id
         permissions = WorkspacePermissions.resolve(
@@ -218,6 +220,28 @@ final class MacIssueDetailModel {
         await update(input)
     }
 
+    func setDueTime(_ time: String?) async {
+        guard let issue else { return }
+        var input = UpdateIssueInput(id: issue.id)
+        if let time { input.dueTime = time } else { input.explicitNulls.insert("dueTime") }
+        await update(input)
+    }
+
+    func setEndTime(_ time: String?) async {
+        guard let issue else { return }
+        var input = UpdateIssueInput(id: issue.id)
+        if let time { input.endTime = time } else { input.explicitNulls.insert("endTime") }
+        await update(input)
+    }
+
+    func setRecurrence(interval: Int?, unit: RecurrenceUnit?) async {
+        guard let issue else { return }
+        var input = UpdateIssueInput(id: issue.id, recurrenceInterval: interval, recurrenceUnit: unit?.rawValue)
+        if interval == nil { input.explicitNulls.insert("recurrenceInterval") }
+        if unit == nil { input.explicitNulls.insert("recurrenceUnit") }
+        await update(input)
+    }
+
     func toggleLabel(_ labelId: String) async {
         guard let issue else { return }
         do {
@@ -237,8 +261,7 @@ final class MacIssueDetailModel {
             self.error = "Can't create label — workspace not resolved yet."
             return
         }
-        let palette = ["#ef4444", "#f59e0b", "#10b981", "#3b82f6", "#8b5cf6", "#ec4899", "#14b8a6"]
-        let color = palette[labels.count % palette.count]
+        let color = LABEL_COLORS[labels.count % LABEL_COLORS.count]
         do {
             let newId = try await deps.labelsApi.create(
                 accountId: accountId,
@@ -256,6 +279,13 @@ final class MacIssueDetailModel {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         do { try await deps.commentsApi.create(accountId: accountId, issueId: issue.id, text: trimmed) }
+        catch { self.error = error.localizedDescription }
+    }
+
+    func updateComment(_ id: String, text: String) async {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        do { try await deps.commentsApi.update(accountId: accountId, id: id, text: trimmed) }
         catch { self.error = error.localizedDescription }
     }
 
@@ -304,7 +334,12 @@ struct MacIssueDetailView: View {
     @State private var showDuePicker = false
     @State private var showLabelPicker = false
     @State private var newLabelName = ""
+    @State private var editingCommentId: String?
+    @State private var editDraft = ""
     @FocusState private var titleFocused: Bool
+
+    // Below this content width the right rail collapses inline under the title.
+    private let railBreakpoint: CGFloat = 900
 
     var body: some View {
         Group {
@@ -323,32 +358,48 @@ struct MacIssueDetailView: View {
         }
         .onDisappear {
             // Flush both buffers — focus-loss may not fire when the detail view is
-            // swapped out wholesale (`.id(selectedIssue)`), so a pending title or
-            // description edit would otherwise be dropped.
+            // swapped out wholesale, so a pending title/description edit would
+            // otherwise be dropped.
             if let m = model { Task { await m.saveTitle(); await m.commitDescription(); m.stop() } }
         }
     }
 
+    // Two-pane on wide windows (web parity: main content + right property rail);
+    // single column with the rail inline under the title when narrow.
     @ViewBuilder
     private func content(_ model: MacIssueDetailModel, issue: IssueEntity) -> some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
-                header(model, issue: issue)
-                Divider()
-                propertyRow(model, issue: issue)
-                labelsSection(model)
-                Divider()
-                descriptionSection(model)
-                Divider()
-                attachmentsSection(model)
-                Divider()
-                commentsSection(model)
-                if let error = model.error {
-                    Text(error).font(.callout).foregroundStyle(.red)
+        GeometryReader { geo in
+            let wide = geo.size.width >= railBreakpoint
+            if wide {
+                HStack(alignment: .top, spacing: 0) {
+                    ScrollView {
+                        mainColumn(model, issue: issue)
+                            .padding(24)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    Divider()
+                    ScrollView {
+                        propertyRail(model, issue: issue).padding(20)
+                    }
+                    .frame(width: 320)
+                }
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 18) {
+                        header(model, issue: issue)
+                        propertyRail(model, issue: issue)
+                        Divider()
+                        descriptionSection(model)
+                        Divider()
+                        attachmentsSection(model)
+                        Divider()
+                        commentsSection(model)
+                        errorText(model)
+                    }
+                    .padding(24)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
-            .padding(24)
-            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .navigationTitle(issue.identifier ?? "Issue")
         .toolbar {
@@ -365,6 +416,26 @@ struct MacIssueDetailView: View {
                 Task { if await model.deleteIssue() { onDelete() } }
             }
             Button("Cancel", role: .cancel) {}
+        }
+    }
+
+    private func mainColumn(_ model: MacIssueDetailModel, issue: IssueEntity) -> some View {
+        VStack(alignment: .leading, spacing: 18) {
+            header(model, issue: issue)
+            Divider()
+            descriptionSection(model)
+            Divider()
+            attachmentsSection(model)
+            Divider()
+            commentsSection(model)
+            errorText(model)
+        }
+    }
+
+    @ViewBuilder
+    private func errorText(_ model: MacIssueDetailModel) -> some View {
+        if let error = model.error {
+            Text(error).font(.callout).foregroundStyle(.red)
         }
     }
 
@@ -386,126 +457,170 @@ struct MacIssueDetailView: View {
         }
     }
 
-    // MARK: - Properties (status / priority / assignee / due date)
+    // MARK: - Property rail (web order: Status / Priority / Assignee / Labels / Due / Project)
 
-    private func propertyRow(_ model: MacIssueDetailModel, issue: IssueEntity) -> some View {
-        HStack(spacing: 14) {
-            Menu {
-                ForEach(IssueStatus.displayOrder, id: \.self) { s in
-                    Button { Task { await model.setStatus(s) } } label: { Label(s.label, systemImage: s.sfSymbol) }
+    @ViewBuilder
+    private func propertyRail(_ model: MacIssueDetailModel, issue: IssueEntity) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            railRow("Status") { statusMenu(model, issue: issue) }
+            railRow("Priority") { priorityMenu(model, issue: issue) }
+            railRow("Assignee") { assigneeMenu(model) }
+            labelsRailRow(model)
+            railRow("Due date") { dueDateControl(model, issue: issue) }
+            if issue.dueDate != nil {
+                railRow("Start time") {
+                    MacTimeFieldButton(value: issue.dueTime) { v in Task { await model.setDueTime(v) } }
+                        .disabled(!model.canModerate)
                 }
-            } label: {
-                let s = IssueStatus.from(issue.status)
-                Label(s.label, systemImage: s.sfSymbol).foregroundStyle(s.color)
-            }
-            .menuStyle(.borderlessButton).fixedSize().disabled(!model.canModerate)
-
-            Menu {
-                ForEach(IssuePriority.displayOrder, id: \.self) { p in
-                    Button { Task { await model.setPriority(p) } } label: { Label(p.label, systemImage: p.sfSymbol) }
+                railRow("End time") {
+                    MacTimeFieldButton(value: issue.endTime) { v in Task { await model.setEndTime(v) } }
+                        .disabled(!model.canModerate)
                 }
-            } label: {
-                let p = IssuePriority.from(issue.priority)
-                Label(p.label, systemImage: p.sfSymbol).foregroundStyle(p.color)
             }
-            .menuStyle(.borderlessButton).fixedSize().disabled(!model.canModerate)
-
-            Menu {
-                Button("Unassigned") { Task { await model.setAssignee(nil) } }
-                Divider()
-                ForEach(model.users) { u in
-                    Button(u.name ?? u.email) { Task { await model.setAssignee(u.id) } }
-                }
-            } label: {
-                Label(model.assignee?.name ?? model.assignee?.email ?? "Unassigned", systemImage: "person.crop.circle")
-                    .foregroundStyle(.secondary)
+            railRow("Repeat") {
+                MacRecurrenceMenu(
+                    interval: issue.recurrenceInterval,
+                    unit: issue.recurrenceUnit,
+                    onSelect: { i, u in Task { await model.setRecurrence(interval: i, unit: u) } },
+                    enabled: model.canModerate
+                )
             }
-            .menuStyle(.borderlessButton).fixedSize().disabled(!model.canModerate)
-
-            dueDateControl(model, issue: issue)
-            Spacer()
+            railRow("Project") {
+                Text(model.projectName ?? "—").font(.subheadline).foregroundStyle(.secondary)
+            }
         }
+        .padding(14)
+        .glassSection()
+        .opacity(model.canModerate ? 1 : 0.7)
+    }
+
+    @ViewBuilder
+    private func railRow<Content: View>(_ label: String, @ViewBuilder content: () -> Content) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label).font(.subheadline).foregroundStyle(.secondary).frame(width: 84, alignment: .leading)
+            Spacer(minLength: 8)
+            content()
+        }
+        .padding(.vertical, 6)
+    }
+
+    private func statusMenu(_ model: MacIssueDetailModel, issue: IssueEntity) -> some View {
+        Menu {
+            ForEach(IssueStatus.displayOrder, id: \.self) { s in
+                Button { Task { await model.setStatus(s) } } label: { Label(s.label, systemImage: s.sfSymbol) }
+            }
+        } label: {
+            let s = IssueStatus.from(issue.status)
+            Label(s.label, systemImage: s.sfSymbol).foregroundStyle(s.color)
+        }
+        .menuStyle(.borderlessButton).fixedSize().disabled(!model.canModerate)
+    }
+
+    private func priorityMenu(_ model: MacIssueDetailModel, issue: IssueEntity) -> some View {
+        Menu {
+            ForEach(IssuePriority.displayOrder, id: \.self) { p in
+                Button { Task { await model.setPriority(p) } } label: { Label(p.label, systemImage: p.sfSymbol) }
+            }
+        } label: {
+            let p = IssuePriority.from(issue.priority)
+            Label(p.label, systemImage: p.sfSymbol).foregroundStyle(p.color)
+        }
+        .menuStyle(.borderlessButton).fixedSize().disabled(!model.canModerate)
+    }
+
+    private func assigneeMenu(_ model: MacIssueDetailModel) -> some View {
+        Menu {
+            Button("Unassigned") { Task { await model.setAssignee(nil) } }
+            Divider()
+            ForEach(model.users) { u in
+                Button(u.name ?? u.email) { Task { await model.setAssignee(u.id) } }
+            }
+        } label: {
+            Label(model.assignee?.name ?? model.assignee?.email ?? "Unassigned", systemImage: "person.crop.circle")
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .menuStyle(.borderlessButton).fixedSize().disabled(!model.canModerate)
     }
 
     // Due date as a button that opens a graphical calendar popover (mirrors the
-    // web's react-day-picker popover + iOS). One tap = one mutation; avoids the
-    // inline stepper-field DatePicker whose computed binding fought the async
-    // Electric round-trip (each sub-component edit mutated, value snapped back).
+    // web's react-day-picker popover + iOS).
     @ViewBuilder
     private func dueDateControl(_ model: MacIssueDetailModel, issue: IssueEntity) -> some View {
         let due = Self.parseDate(issue.dueDate)
-        Button { showDuePicker = true } label: {
-            Label(
-                due.map { $0.formatted(date: .abbreviated, time: .omitted) } ?? "Add due date",
-                systemImage: due == nil ? "calendar.badge.plus" : "calendar"
-            )
-            .foregroundStyle(due == nil ? Color.secondary : Color.primary)
-        }
-        .buttonStyle(.borderless)
-        .fixedSize()
-        .disabled(!model.canModerate)
-        .popover(isPresented: $showDuePicker, arrowEdge: .bottom) {
-            DatePicker(
-                "Due date",
-                selection: Binding(
-                    get: { due ?? Date() },
-                    set: { newDate in
-                        showDuePicker = false
-                        Task { await model.setDueDate(newDate) }
-                    }
-                ),
-                displayedComponents: [.date]
-            )
-            .datePickerStyle(.graphical)
-            .labelsHidden()
-            .padding(12)
-        }
-
-        if due != nil {
-            Button { Task { await model.setDueDate(nil) } } label: {
-                Image(systemName: "xmark.circle.fill")
-            }
-            .buttonStyle(.borderless)
-            .foregroundStyle(.tertiary)
-            .disabled(!model.canModerate)
-        }
-    }
-
-    // MARK: - Labels
-
-    @ViewBuilder
-    private func labelsSection(_ model: MacIssueDetailModel) -> some View {
-        HStack(spacing: 6) {
-            Button { showLabelPicker = true } label: {
-                Label("Label", systemImage: "tag").font(.caption)
+        HStack(spacing: 4) {
+            Button { showDuePicker = true } label: {
+                Label(
+                    due.map { $0.formatted(date: .abbreviated, time: .omitted) } ?? "Add due date",
+                    systemImage: due == nil ? "calendar.badge.plus" : "calendar"
+                )
+                .foregroundStyle(due == nil ? Color.secondary : Color.primary)
             }
             .buttonStyle(.borderless)
             .fixedSize()
-            .foregroundStyle(.secondary)
-            .disabled(!model.canEditContent)
-            .popover(isPresented: $showLabelPicker, arrowEdge: .bottom) {
-                labelPicker(model)
+            .disabled(!model.canModerate)
+            .popover(isPresented: $showDuePicker, arrowEdge: .bottom) {
+                DatePicker(
+                    "Due date",
+                    selection: Binding(
+                        get: { due ?? Date() },
+                        set: { newDate in
+                            showDuePicker = false
+                            Task { await model.setDueDate(newDate) }
+                        }
+                    ),
+                    displayedComponents: [.date]
+                )
+                .datePickerStyle(.graphical)
+                .labelsHidden()
+                .padding(12)
             }
-
-            ForEach(model.assignedLabels) { label in
-                Button { Task { await model.toggleLabel(label.id) } } label: {
-                    HStack(spacing: 4) {
-                        Circle().fill(Color(hex: label.color) ?? .gray).frame(width: 8, height: 8)
-                        Text(label.name).font(.caption)
-                        Image(systemName: "xmark").font(.system(size: 8, weight: .bold)).foregroundStyle(.tertiary)
-                    }
-                    .padding(.horizontal, 8).padding(.vertical, 3)
+            if due != nil {
+                Button { Task { await model.setDueDate(nil) } } label: {
+                    Image(systemName: "xmark.circle.fill")
                 }
-                .buttonStyle(.plain)
-                .glassButton()
-                .disabled(!model.canEditContent)
+                .buttonStyle(.borderless)
+                .foregroundStyle(.tertiary)
+                .disabled(!model.canModerate)
             }
-            Spacer(minLength: 0)
         }
     }
 
-    // Popover label picker (plain Buttons — reliable, unlike the icon Menu) with
-    // inline create, mirroring the web/iOS label picker.
+    // MARK: - Labels (rail row)
+
+    @ViewBuilder
+    private func labelsRailRow(_ model: MacIssueDetailModel) -> some View {
+        HStack(alignment: .top) {
+            Text("Labels").font(.subheadline).foregroundStyle(.secondary).frame(width: 84, alignment: .leading)
+            Spacer(minLength: 8)
+            VStack(alignment: .trailing, spacing: 6) {
+                Button { showLabelPicker = true } label: { Label("Add", systemImage: "tag").font(.caption) }
+                    .buttonStyle(.borderless)
+                    .foregroundStyle(.secondary)
+                    .disabled(!model.canEditContent)
+                    .popover(isPresented: $showLabelPicker, arrowEdge: .bottom) { labelPicker(model) }
+                if !model.assignedLabels.isEmpty {
+                    MacFlowLayout(spacing: 6) {
+                        ForEach(model.assignedLabels) { label in
+                            Button { Task { await model.toggleLabel(label.id) } } label: {
+                                HStack(spacing: 4) {
+                                    Circle().fill(Color(hex: label.color) ?? .gray).frame(width: 8, height: 8)
+                                    Text(label.name).font(.caption)
+                                    Image(systemName: "xmark").font(.system(size: 8, weight: .bold)).foregroundStyle(.tertiary)
+                                }
+                                .padding(.horizontal, 8).padding(.vertical, 3)
+                            }
+                            .buttonStyle(.plain)
+                            .glassButton()
+                            .disabled(!model.canEditContent)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 6)
+    }
+
     @ViewBuilder
     private func labelPicker(_ model: MacIssueDetailModel) -> some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -591,11 +706,12 @@ struct MacIssueDetailView: View {
         }
     }
 
-    // MARK: - Comments
+    // MARK: - Comments (timeline with relative time, edit/delete)
 
     private func commentsSection(_ model: MacIssueDetailModel) -> some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("Comments").font(.subheadline.weight(.medium)).foregroundStyle(.secondary)
+            Text(model.comments.isEmpty ? "Comments" : "Comments (\(model.comments.count))")
+                .font(.subheadline.weight(.medium)).foregroundStyle(.secondary)
             ForEach(model.comments) { comment in
                 commentRow(comment, model: model)
             }
@@ -618,20 +734,46 @@ struct MacIssueDetailView: View {
         let author = model.user(comment.authorId)
         let body = getCommentBodyText(comment.body)
         let kind = comment.commentKind
+        let canModify = comment.authorId == deps.auth.userId || deps.auth.isAdmin
+        let isEditing = editingCommentId == comment.id
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 6) {
                 Text(author?.name ?? author?.email ?? "Unknown").font(.caption.weight(.semibold))
                 if kind == .question { Text("asks").font(.caption).foregroundStyle(.purple) }
-                if kind == .plan { Text("plan").font(.caption).foregroundStyle(.blue) }
+                if kind == .plan { Text("plan").font(.caption).foregroundStyle(Accent.indigo) }
+                Text(macRelativeDate(comment.createdAt)).font(.caption2).foregroundStyle(.tertiary)
+                if comment.editedAt != nil {
+                    Text("· edited").font(.caption2).foregroundStyle(.tertiary)
+                }
                 Spacer()
-                if comment.authorId == deps.auth.userId || deps.auth.isAdmin {
-                    Button { Task { await model.deleteComment(comment.id) } } label: {
-                        Image(systemName: "trash").font(.caption2)
+                if canModify && !isEditing {
+                    Menu {
+                        if kind == .regular {
+                            Button("Edit") { editDraft = body; editingCommentId = comment.id }
+                        }
+                        Button("Delete", role: .destructive) { Task { await model.deleteComment(comment.id) } }
+                    } label: {
+                        Image(systemName: "ellipsis").font(.caption2)
                     }
-                    .buttonStyle(.borderless).foregroundStyle(.tertiary)
+                    .menuStyle(.borderlessButton).fixedSize()
                 }
             }
-            Text(body).font(.callout).textSelection(.enabled)
+            if isEditing {
+                TextField("Edit comment", text: $editDraft, axis: .vertical)
+                    .textFieldStyle(.roundedBorder)
+                    .lineLimit(1...6)
+                HStack {
+                    Button("Save") {
+                        let t = editDraft
+                        editingCommentId = nil
+                        Task { await model.updateComment(comment.id, text: t) }
+                    }
+                    .buttonStyle(.borderedProminent).tint(Accent.indigo).controlSize(.small)
+                    Button("Cancel") { editingCommentId = nil }.controlSize(.small)
+                }
+            } else {
+                Text(body).font(.callout).textSelection(.enabled)
+            }
             if kind == .plan, model.issue?.agentPlanState == "awaiting_approval",
                model.permissions?.canApprovePlan(creatorId: model.issue?.creatorId) == true {
                 HStack(spacing: 8) {
@@ -651,7 +793,7 @@ struct MacIssueDetailView: View {
         switch kind {
         case .regular: Color.white.opacity(0.04)
         case .question: Color.purple.opacity(0.10)
-        case .plan: Color.blue.opacity(0.10)
+        case .plan: Accent.indigo.opacity(0.10)
         }
     }
 

--- a/apps/ios/ExponentialMac/MacIssueListView.swift
+++ b/apps/ios/ExponentialMac/MacIssueListView.swift
@@ -230,7 +230,7 @@ struct MacIssueListView: View {
                 Text((assignee.name ?? assignee.email).prefix(1).uppercased())
                     .font(.caption2.weight(.bold))
                     .frame(width: 18, height: 18)
-                    .background(Circle().fill(Color.blue.opacity(0.6)))
+                    .background(Circle().fill(Accent.indigo.opacity(0.6)))
             }
         }
         .padding(.vertical, 2)

--- a/apps/ios/ExponentialMac/MacIssueListView.swift
+++ b/apps/ios/ExponentialMac/MacIssueListView.swift
@@ -111,37 +111,54 @@ struct MacIssueListView: View {
     @State private var model: MacIssueListModel?
     @State private var search = ""
     @State private var showCreate = false
+    @State private var createStatus: IssueStatus = .backlog
 
     var body: some View {
         Group {
             if let model {
-                List {
-                    ForEach(IssueStatus.displayOrder, id: \.self) { status in
-                        let items = model.issues(in: status, search: search)
-                        if !items.isEmpty {
-                            Section {
-                                ForEach(items) { issue in
-                                    NavigationLink(value: IssueRef(accountId: accountId, issueId: issue.id)) {
-                                        row(issue, model: model)
+                VStack(spacing: 0) {
+                    // All / Active / Backlog presets (ExpCore FilterTab), the
+                    // macOS-native substitute for the iOS pill scroll strip.
+                    Picker("Filter", selection: tabBinding(model)) {
+                        ForEach(FilterTab.allCases) { Text($0.label).tag($0) }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+
+                    List {
+                        ForEach(IssueStatus.displayOrder, id: \.self) { status in
+                            let items = model.issues(in: status, search: search)
+                            if !items.isEmpty {
+                                Section {
+                                    ForEach(items) { issue in
+                                        NavigationLink(value: IssueRef(accountId: accountId, issueId: issue.id)) {
+                                            row(issue, model: model)
+                                        }
                                     }
+                                } header: {
+                                    sectionHeader(status, model: model)
                                 }
-                            } header: {
-                                Label(status.label, systemImage: status.sfSymbol).foregroundStyle(status.color)
                             }
                         }
                     }
+                    .listStyle(.inset)
                 }
-                .listStyle(.inset)
                 .searchable(text: $search, prompt: "Search issues")
                 .navigationTitle(model.project?.name ?? "Issues")
                 .toolbar { toolbar(model) }
                 .sheet(isPresented: $showCreate) {
-                    MacCreateIssueView(accountId: accountId, projectId: projectId, users: model.users) {
-                        showCreate = false
-                    }
+                    MacCreateIssueView(
+                        accountId: accountId,
+                        projectId: projectId,
+                        users: model.users,
+                        labels: model.availableLabels,
+                        initialStatus: createStatus
+                    )
                 }
                 // Publish ⌘N for the app menu while this project is in scene focus.
-                .focusedSceneValue(\.createIssueAction, model.canCreate ? { showCreate = true } : nil)
+                .focusedSceneValue(\.createIssueAction, model.canCreate ? { createStatus = .backlog; showCreate = true } : nil)
             } else {
                 ProgressView()
             }
@@ -186,9 +203,29 @@ struct MacIssueListView: View {
             .help("Filter")
         }
         ToolbarItem {
-            Button { showCreate = true } label: { Image(systemName: "plus") }
+            Button { createStatus = .backlog; showCreate = true } label: { Image(systemName: "plus") }
                 .disabled(!model.canCreate)
                 .help("New issue")
+        }
+    }
+
+    private func tabBinding(_ model: MacIssueListModel) -> Binding<FilterTab> {
+        Binding(
+            get: { deriveTab(from: model.filters.statuses) },
+            set: { model.filters.statuses = $0.statuses }
+        )
+    }
+
+    private func sectionHeader(_ status: IssueStatus, model: MacIssueListModel) -> some View {
+        HStack {
+            Label(status.label, systemImage: status.sfSymbol).foregroundStyle(status.color)
+            Spacer()
+            if model.canCreate {
+                Button { createStatus = status; showCreate = true } label: { Image(systemName: "plus") }
+                    .buttonStyle(.borderless)
+                    .foregroundStyle(.secondary)
+                    .help("New \(status.label) issue")
+            }
         }
     }
 
@@ -220,6 +257,9 @@ struct MacIssueListView: View {
                 .frame(width: 16)
             if let identifier = issue.identifier {
                 Text(identifier).font(.caption.monospaced()).foregroundStyle(.tertiary)
+            }
+            if issue.recurrenceInterval != nil {
+                Image(systemName: "repeat").font(.caption2).foregroundStyle(.tertiary)
             }
             Text(issue.title).lineLimit(1)
             Spacer()

--- a/apps/ios/ExponentialMac/MacLoginView.swift
+++ b/apps/ios/ExponentialMac/MacLoginView.swift
@@ -56,6 +56,7 @@ struct MacLoginView: View {
             }
             .controlSize(.large)
             .buttonStyle(.borderedProminent)
+            .tint(Accent.indigo)
 
             orSeparator
 
@@ -113,6 +114,7 @@ struct MacLoginView: View {
                     }
                     .controlSize(.large)
                     .buttonStyle(.borderedProminent)
+                    .tint(Accent.indigo)
                     .disabled(vm.loading || vm.email.isEmpty || vm.password.isEmpty)
                 }
             }

--- a/apps/ios/ExponentialMac/MacMarkdownEditor.swift
+++ b/apps/ios/ExponentialMac/MacMarkdownEditor.swift
@@ -687,6 +687,7 @@ struct MacMarkdownEditor: View {
                     Button("Cancel") { showLinkPrompt = false }
                     Button("Add") { controller.applyLink(linkText); showLinkPrompt = false }
                         .buttonStyle(.borderedProminent)
+                        .tint(Accent.indigo)
                 }
             }
             .padding(20)

--- a/apps/ios/ExponentialMac/MacShell.swift
+++ b/apps/ios/ExponentialMac/MacShell.swift
@@ -20,11 +20,31 @@ struct MacShell: View {
     @State private var selectedProject: ProjectRef?
     @State private var issuePath: [IssueRef] = []
     @State private var settingsTarget: WorkspaceSettingsTarget?
+    @State private var createProjectTarget: WorkspaceSettingsTarget?
     @State private var showAdmin = false
     @State private var showIntegrations = false
+    @State private var showCreateWorkspace = false
+    @State private var ensuredDefault = false
 
     private var activeAccount: ServerAccount? {
         deps.auth.accounts.first { $0.id == deps.auth.activeAccountId }
+    }
+
+    // The workspace of the selected project, else the first synced workspace —
+    // the "active workspace" the switcher checkmarks and new-project targets.
+    private var activeWorkspace: (accountId: String, workspace: WorkspaceEntity)? {
+        let groups = projectLoader?.groups ?? []
+        if let sel = selectedProject {
+            for group in groups where group.accountId == sel.accountId {
+                for block in group.workspaceBlocks where block.projects.contains(where: { $0.id == sel.projectId }) {
+                    return (group.accountId, block.workspace)
+                }
+            }
+        }
+        if let group = groups.first, let block = group.workspaceBlocks.first {
+            return (group.accountId, block.workspace)
+        }
+        return nil
     }
 
     var body: some View {
@@ -44,7 +64,7 @@ struct MacShell: View {
                         )
                         .id(selectedProject)
                     } else {
-                        ContentUnavailableView("Select a project", systemImage: "folder")
+                        emptyState
                     }
                 }
                 .navigationDestination(for: IssueRef.self) { ref in
@@ -59,6 +79,12 @@ struct MacShell: View {
         .onAppear {
             if projectLoader == nil {
                 projectLoader = MultiAccountProjectLoader(auth: deps.auth, db: deps.db)
+            }
+            // Make sure a fresh account lands in a usable workspace (idempotent
+            // server-side) so the sidebar is never empty after first sign-in.
+            if !ensuredDefault, let id = activeAccount?.id {
+                ensuredDefault = true
+                Task { try? await deps.workspacesApi.ensureDefault(accountId: id) }
             }
         }
         .onChange(of: deps.auth.accounts) { _, _ in projectLoader?.refresh() }
@@ -89,6 +115,42 @@ struct MacShell: View {
                     .preferredColorScheme(.dark)
             }
         }
+        .sheet(item: $createProjectTarget) { target in
+            MacCreateProjectView(accountId: target.accountId, workspaceId: target.workspaceId) { newId in
+                selectedProject = ProjectRef(accountId: target.accountId, projectId: newId)
+            }
+            .environment(deps)
+            .preferredColorScheme(.dark)
+        }
+        .sheet(isPresented: $showCreateWorkspace) {
+            if let account = activeAccount {
+                MacCreateWorkspaceView(accountId: account.id)
+                    .environment(deps)
+                    .preferredColorScheme(.dark)
+            }
+        }
+    }
+
+    // MARK: - Empty state
+
+    @ViewBuilder
+    private var emptyState: some View {
+        if (projectLoader?.groups ?? []).isEmpty {
+            ContentUnavailableView {
+                Label("No projects yet", systemImage: "folder.badge.plus")
+            } description: {
+                Text("Create a workspace and a project to get started.")
+            } actions: {
+                Button("New Workspace") { showCreateWorkspace = true }
+                if let aw = activeWorkspace {
+                    Button("New Project") {
+                        createProjectTarget = WorkspaceSettingsTarget(accountId: aw.accountId, workspaceId: aw.workspace.id)
+                    }
+                }
+            }
+        } else {
+            ContentUnavailableView("Select a project", systemImage: "folder")
+        }
     }
 
     @ViewBuilder
@@ -107,7 +169,69 @@ struct MacShell: View {
             }
         }
         .listStyle(.sidebar)
+        .safeAreaInset(edge: .top) { sidebarHeader }
         .safeAreaInset(edge: .bottom) { sidebarFooter }
+    }
+
+    @ViewBuilder
+    private var sidebarHeader: some View {
+        HStack(spacing: 6) {
+            workspaceSwitcher
+            Spacer(minLength: 4)
+            Button {
+                if let aw = activeWorkspace {
+                    createProjectTarget = WorkspaceSettingsTarget(accountId: aw.accountId, workspaceId: aw.workspace.id)
+                }
+            } label: {
+                Image(systemName: "plus")
+            }
+            .buttonStyle(.borderless)
+            .disabled(activeWorkspace == nil)
+            .help("New project")
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+    }
+
+    private var workspaceSwitcher: some View {
+        Menu {
+            ForEach(projectLoader?.groups ?? []) { group in
+                ForEach(group.workspaceBlocks) { block in
+                    Button {
+                        if let first = block.projects.first {
+                            selectedProject = ProjectRef(accountId: group.accountId, projectId: first.id)
+                        }
+                    } label: {
+                        if activeWorkspace?.workspace.id == block.workspace.id {
+                            Label(block.workspace.name, systemImage: "checkmark")
+                        } else {
+                            Text(block.workspace.name)
+                        }
+                    }
+                }
+            }
+            Divider()
+            Button { showCreateWorkspace = true } label: { Label("New workspace", systemImage: "plus") }
+            if let aw = activeWorkspace {
+                Button {
+                    settingsTarget = WorkspaceSettingsTarget(accountId: aw.accountId, workspaceId: aw.workspace.id)
+                } label: {
+                    Label("Workspace Settings…", systemImage: "gearshape")
+                }
+            }
+        } label: {
+            HStack(spacing: 6) {
+                if let aw = activeWorkspace {
+                    WorkspaceAvatar(workspace: aw.workspace, size: 16)
+                    Text(aw.workspace.name).font(.subheadline.weight(.medium)).lineLimit(1)
+                } else {
+                    Text("Workspaces").font(.subheadline.weight(.medium))
+                }
+                Image(systemName: "chevron.down").font(.caption2).foregroundStyle(.tertiary)
+            }
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
     }
 
     @ViewBuilder

--- a/apps/ios/ExponentialMac/MacShell.swift
+++ b/apps/ios/ExponentialMac/MacShell.swift
@@ -84,7 +84,12 @@ struct MacShell: View {
             // server-side) so the sidebar is never empty after first sign-in.
             if !ensuredDefault, let id = activeAccount?.id {
                 ensuredDefault = true
-                Task { try? await deps.workspacesApi.ensureDefault(accountId: id) }
+                Task {
+                    try? await deps.workspacesApi.ensureDefault(accountId: id)
+                    // Re-establish the observation so a just-created default workspace
+                    // surfaces as soon as Electric syncs it, not only on the next tick.
+                    projectLoader?.refresh()
+                }
             }
         }
         .onChange(of: deps.auth.accounts) { _, _ in projectLoader?.refresh() }

--- a/apps/ios/ExponentialMac/MacShell.swift
+++ b/apps/ios/ExponentialMac/MacShell.swift
@@ -178,10 +178,27 @@ struct MacShell: View {
         .safeAreaInset(edge: .bottom) { sidebarFooter }
     }
 
+    // Workspace name is rendered as a PLAIN view (not inside a Menu label) — a
+    // borderlessButton menu collapses a rich label to its smallest content, which
+    // truncated the name to a single letter. The menu hangs off the chevron only.
     @ViewBuilder
     private var sidebarHeader: some View {
         HStack(spacing: 6) {
-            workspaceSwitcher
+            if let aw = activeWorkspace {
+                WorkspaceAvatar(workspace: aw.workspace, size: 18)
+            }
+            Text(activeWorkspace?.workspace.name ?? "Workspaces")
+                .font(.subheadline.weight(.semibold))
+                .lineLimit(1)
+                .truncationMode(.tail)
+            Menu {
+                workspaceMenuItems
+            } label: {
+                Image(systemName: "chevron.up.chevron.down").font(.caption2).foregroundStyle(.secondary)
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
             Spacer(minLength: 4)
             Button {
                 if let aw = activeWorkspace {
@@ -198,85 +215,74 @@ struct MacShell: View {
         .padding(.vertical, 6)
     }
 
-    private var workspaceSwitcher: some View {
-        Menu {
-            ForEach(projectLoader?.groups ?? []) { group in
-                ForEach(group.workspaceBlocks) { block in
-                    Button {
-                        if let first = block.projects.first {
-                            selectedProject = ProjectRef(accountId: group.accountId, projectId: first.id)
-                        }
-                    } label: {
-                        if activeWorkspace?.workspace.id == block.workspace.id {
-                            Label(block.workspace.name, systemImage: "checkmark")
-                        } else {
-                            Text(block.workspace.name)
-                        }
+    @ViewBuilder
+    private var workspaceMenuItems: some View {
+        ForEach(projectLoader?.groups ?? []) { group in
+            ForEach(group.workspaceBlocks) { block in
+                Button {
+                    if let first = block.projects.first {
+                        selectedProject = ProjectRef(accountId: group.accountId, projectId: first.id)
+                    }
+                } label: {
+                    if activeWorkspace?.workspace.id == block.workspace.id {
+                        Label(block.workspace.name, systemImage: "checkmark")
+                    } else {
+                        Text(block.workspace.name)
                     }
                 }
             }
-            Divider()
-            Button { showCreateWorkspace = true } label: { Label("New workspace", systemImage: "plus") }
-            if let aw = activeWorkspace {
-                Button {
-                    settingsTarget = WorkspaceSettingsTarget(accountId: aw.accountId, workspaceId: aw.workspace.id)
-                } label: {
-                    Label("Workspace Settings…", systemImage: "gearshape")
-                }
-            }
-        } label: {
-            HStack(spacing: 6) {
-                if let aw = activeWorkspace {
-                    WorkspaceAvatar(workspace: aw.workspace, size: 16)
-                    Text(aw.workspace.name).font(.subheadline.weight(.medium)).lineLimit(1)
-                } else {
-                    Text("Workspaces").font(.subheadline.weight(.medium))
-                }
-                Image(systemName: "chevron.down").font(.caption2).foregroundStyle(.tertiary)
+        }
+        Divider()
+        Button { showCreateWorkspace = true } label: { Label("New workspace", systemImage: "plus") }
+        if let aw = activeWorkspace {
+            Button {
+                settingsTarget = WorkspaceSettingsTarget(accountId: aw.accountId, workspaceId: aw.workspace.id)
+            } label: {
+                Label("Workspace Settings…", systemImage: "gearshape")
             }
         }
-        .menuStyle(.borderlessButton)
-        .fixedSize()
     }
 
+    // Identity name + email are PLAIN views (same reason as the header); the
+    // account menu hangs off the trailing ellipsis only.
     @ViewBuilder
     private var sidebarFooter: some View {
         if let account = activeAccount {
-            Menu {
-                if deps.auth.isAdmin {
-                    Button { showAdmin = true } label: { Label("Admin", systemImage: "shield") }
-                }
-                Button { showIntegrations = true } label: {
-                    Label("Integrations", systemImage: "puzzlepiece.extension")
-                }
-                Button { openFeedback() } label: { Label("Send feedback", systemImage: "envelope") }
-                Divider()
-                Button(role: .destructive) { signOut(account) } label: {
-                    Label("Sign out", systemImage: "rectangle.portrait.and.arrow.right")
-                }
-            } label: {
-                HStack(spacing: 8) {
-                    Text((account.userEmail ?? account.displayName).prefix(1).uppercased())
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.white)
-                        .frame(width: 24, height: 24)
-                        .background(Accent.indigo.opacity(0.7))
-                        .clipShape(Circle())
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text(account.displayName).font(.caption.weight(.medium)).lineLimit(1)
-                        if let email = account.userEmail, !email.isEmpty {
-                            Text(email).font(.caption2).foregroundStyle(.secondary).lineLimit(1)
-                        }
+            HStack(spacing: 8) {
+                Text((account.userEmail ?? account.displayName).prefix(1).uppercased())
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.white)
+                    .frame(width: 24, height: 24)
+                    .background(Accent.indigo.opacity(0.7))
+                    .clipShape(Circle())
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(account.displayName).font(.caption.weight(.medium)).lineLimit(1)
+                    if let email = account.userEmail, !email.isEmpty {
+                        Text(email).font(.caption2).foregroundStyle(.secondary).lineLimit(1)
                     }
-                    Spacer()
-                    Image(systemName: "chevron.up.chevron.down").font(.caption2).foregroundStyle(.tertiary)
                 }
-                .padding(.horizontal, 10)
-                .padding(.vertical, 8)
-                .contentShape(Rectangle())
+                Spacer(minLength: 4)
+                Menu {
+                    if deps.auth.isAdmin {
+                        Button { showAdmin = true } label: { Label("Admin", systemImage: "shield") }
+                    }
+                    Button { showIntegrations = true } label: {
+                        Label("Integrations", systemImage: "puzzlepiece.extension")
+                    }
+                    Button { openFeedback() } label: { Label("Send feedback", systemImage: "envelope") }
+                    Divider()
+                    Button(role: .destructive) { signOut(account) } label: {
+                        Label("Sign out", systemImage: "rectangle.portrait.and.arrow.right")
+                    }
+                } label: {
+                    Image(systemName: "ellipsis").font(.body).foregroundStyle(.secondary)
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .fixedSize()
             }
-            .menuStyle(.borderlessButton)
-            .padding(8)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
         }
     }
 

--- a/apps/ios/ExponentialMac/MacShell.swift
+++ b/apps/ios/ExponentialMac/MacShell.swift
@@ -120,16 +120,3 @@ struct MacShell: View {
     }
 }
 
-extension Color {
-    /// Best-effort `#rrggbb` parsing for project accent colors.
-    init?(hex: String?) {
-        guard var hex, !hex.isEmpty else { return nil }
-        if hex.hasPrefix("#") { hex.removeFirst() }
-        guard hex.count == 6, let value = Int(hex, radix: 16) else { return nil }
-        self = Color(
-            red: Double((value >> 16) & 0xFF) / 255,
-            green: Double((value >> 8) & 0xFF) / 255,
-            blue: Double(value & 0xFF) / 255
-        )
-    }
-}

--- a/apps/ios/ExponentialMac/MacShell.swift
+++ b/apps/ios/ExponentialMac/MacShell.swift
@@ -12,6 +12,11 @@ struct IssueRef: Hashable {
     let issueId: String
 }
 
+struct WorkspaceRef: Hashable {
+    let accountId: String
+    let workspaceId: String
+}
+
 /// The main three-column shell: project sidebar | issue list | issue detail.
 /// Read-only for A2; selection drives the list and detail columns.
 struct MacShell: View {
@@ -25,26 +30,41 @@ struct MacShell: View {
     @State private var showIntegrations = false
     @State private var showCreateWorkspace = false
     @State private var ensuredDefault = false
+    // The workspace the sidebar is currently scoped to (web shows ONE workspace's
+    // projects at a time, switched via the dropdown — not every workspace flat).
+    @State private var selectedWorkspace: WorkspaceRef?
 
     private var activeAccount: ServerAccount? {
         deps.auth.accounts.first { $0.id == deps.auth.activeAccountId }
     }
 
-    // The workspace of the selected project, else the first synced workspace —
-    // the "active workspace" the switcher checkmarks and new-project targets.
-    private var activeWorkspace: (accountId: String, workspace: WorkspaceEntity)? {
+    // The (account, workspace-block) the sidebar shows: the explicit switcher
+    // choice, else the workspace of the selected project, else the first synced
+    // workspace. The block carries that workspace's projects.
+    private var activeWorkspaceBlock: (accountId: String, block: WorkspaceBlock)? {
         let groups = projectLoader?.groups ?? []
+        if let sel = selectedWorkspace {
+            for group in groups where group.accountId == sel.accountId {
+                for block in group.workspaceBlocks where block.workspace.id == sel.workspaceId {
+                    return (group.accountId, block)
+                }
+            }
+        }
         if let sel = selectedProject {
             for group in groups where group.accountId == sel.accountId {
                 for block in group.workspaceBlocks where block.projects.contains(where: { $0.id == sel.projectId }) {
-                    return (group.accountId, block.workspace)
+                    return (group.accountId, block)
                 }
             }
         }
         if let group = groups.first, let block = group.workspaceBlocks.first {
-            return (group.accountId, block.workspace)
+            return (group.accountId, block)
         }
         return nil
+    }
+
+    private var activeWorkspace: (accountId: String, workspace: WorkspaceEntity)? {
+        activeWorkspaceBlock.map { ($0.accountId, $0.block.workspace) }
     }
 
     var body: some View {
@@ -99,6 +119,7 @@ struct MacShell: View {
         // pool — clear it so the list/detail never query the wrong account.
         .onChange(of: deps.auth.activeAccountId) { _, _ in
             selectedProject = nil
+            selectedWorkspace = nil
             issuePath.removeAll()
         }
         .sheet(item: $settingsTarget) { target in
@@ -161,13 +182,16 @@ struct MacShell: View {
     @ViewBuilder
     private var sidebar: some View {
         List(selection: $selectedProject) {
-            ForEach(projectLoader?.groups ?? []) { group in
-                Section(group.hostname) {
-                    ForEach(group.workspaceBlocks) { block in
-                        workspaceHeader(block.workspace, accountId: group.accountId)
+            if let (accountId, block) = activeWorkspaceBlock {
+                Section("Projects") {
+                    if block.projects.isEmpty {
+                        Text("No projects yet")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
                         ForEach(block.projects) { project in
                             projectRow(project)
-                                .tag(ProjectRef(accountId: group.accountId, projectId: project.id))
+                                .tag(ProjectRef(accountId: accountId, projectId: project.id))
                         }
                     }
                 }
@@ -220,9 +244,10 @@ struct MacShell: View {
         ForEach(projectLoader?.groups ?? []) { group in
             ForEach(group.workspaceBlocks) { block in
                 Button {
-                    if let first = block.projects.first {
-                        selectedProject = ProjectRef(accountId: group.accountId, projectId: first.id)
-                    }
+                    // Scope the sidebar to this workspace; clear the open project so
+                    // the content resets to that workspace's empty state.
+                    selectedWorkspace = WorkspaceRef(accountId: group.accountId, workspaceId: block.workspace.id)
+                    selectedProject = nil
                 } label: {
                     if activeWorkspace?.workspace.id == block.workspace.id {
                         Label(block.workspace.name, systemImage: "checkmark")
@@ -300,23 +325,6 @@ struct MacShell: View {
             await deps.syncManager.signOut(accountId: id)
             deps.db.closePool(forAccountId: id)
             deps.auth.removeAccount(id: id)
-        }
-    }
-
-    private func workspaceHeader(_ workspace: WorkspaceEntity, accountId: String) -> some View {
-        HStack(spacing: 6) {
-            WorkspaceAvatar(workspace: workspace, size: 16)
-            Text(workspace.name)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-            Spacer()
-        }
-        .padding(.top, 4)
-        .contentShape(Rectangle())
-        .contextMenu {
-            Button("Workspace Settings…") {
-                settingsTarget = WorkspaceSettingsTarget(accountId: accountId, workspaceId: workspace.id)
-            }
         }
     }
 

--- a/apps/ios/ExponentialMac/MacShell.swift
+++ b/apps/ios/ExponentialMac/MacShell.swift
@@ -20,6 +20,12 @@ struct MacShell: View {
     @State private var selectedProject: ProjectRef?
     @State private var issuePath: [IssueRef] = []
     @State private var settingsTarget: WorkspaceSettingsTarget?
+    @State private var showAdmin = false
+    @State private var showIntegrations = false
+
+    private var activeAccount: ServerAccount? {
+        deps.auth.accounts.first { $0.id == deps.auth.activeAccountId }
+    }
 
     var body: some View {
         NavigationSplitView {
@@ -69,6 +75,20 @@ struct MacShell: View {
                 .environment(deps)
                 .preferredColorScheme(.dark)
         }
+        .sheet(isPresented: $showAdmin) {
+            if let account = activeAccount {
+                MacAdminView(accountId: account.id)
+                    .environment(deps)
+                    .preferredColorScheme(.dark)
+            }
+        }
+        .sheet(isPresented: $showIntegrations) {
+            if let account = activeAccount {
+                MacIntegrationsView(accountId: account.id)
+                    .environment(deps)
+                    .preferredColorScheme(.dark)
+            }
+        }
     }
 
     @ViewBuilder
@@ -87,6 +107,65 @@ struct MacShell: View {
             }
         }
         .listStyle(.sidebar)
+        .safeAreaInset(edge: .bottom) { sidebarFooter }
+    }
+
+    @ViewBuilder
+    private var sidebarFooter: some View {
+        if let account = activeAccount {
+            Menu {
+                if deps.auth.isAdmin {
+                    Button { showAdmin = true } label: { Label("Admin", systemImage: "shield") }
+                }
+                Button { showIntegrations = true } label: {
+                    Label("Integrations", systemImage: "puzzlepiece.extension")
+                }
+                Button { openFeedback() } label: { Label("Send feedback", systemImage: "envelope") }
+                Divider()
+                Button(role: .destructive) { signOut(account) } label: {
+                    Label("Sign out", systemImage: "rectangle.portrait.and.arrow.right")
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    Text((account.userEmail ?? account.displayName).prefix(1).uppercased())
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.white)
+                        .frame(width: 24, height: 24)
+                        .background(Accent.indigo.opacity(0.7))
+                        .clipShape(Circle())
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(account.displayName).font(.caption.weight(.medium)).lineLimit(1)
+                        if let email = account.userEmail, !email.isEmpty {
+                            Text(email).font(.caption2).foregroundStyle(.secondary).lineLimit(1)
+                        }
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.up.chevron.down").font(.caption2).foregroundStyle(.tertiary)
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .contentShape(Rectangle())
+            }
+            .menuStyle(.borderlessButton)
+            .padding(8)
+        }
+    }
+
+    private func openFeedback() {
+        guard let base = deps.auth.instanceUrl,
+              let url = URL(string: "\(base)/w/feedback/projects/feedback") else { return }
+        Platform.open(url)
+    }
+
+    private func signOut(_ account: ServerAccount) {
+        let id = account.id
+        // Tear sync down first (it still references the token + DB pool), then
+        // remove the account so we never yank state out from under the sync task.
+        Task {
+            await deps.syncManager.signOut(accountId: id)
+            deps.db.closePool(forAccountId: id)
+            deps.auth.removeAccount(id: id)
+        }
     }
 
     private func workspaceHeader(_ workspace: WorkspaceEntity, accountId: String) -> some View {

--- a/apps/ios/ExponentialMac/MacWorkspaceSettingsView.swift
+++ b/apps/ios/ExponentialMac/MacWorkspaceSettingsView.swift
@@ -88,6 +88,19 @@ final class MacWorkspaceSettingsModel {
         Task { do { try await op() } catch { self.error = error.localizedDescription } }
     }
 
+    func setName(_ name: String) {
+        run { [self] in
+            try await deps.workspacesApi.update(accountId: accountId, UpdateWorkspaceInput(id: workspaceId, name: name))
+        }
+    }
+
+    func deleteWorkspace(onSuccess: @escaping () -> Void) {
+        run { [self] in
+            try await deps.workspacesApi.delete(accountId: accountId, workspaceId: workspaceId)
+            onSuccess()
+        }
+    }
+
     func setPublic(_ isPublic: Bool) {
         run { [self] in
             try await deps.workspacesApi.update(accountId: accountId, UpdateWorkspaceInput(
@@ -136,6 +149,12 @@ final class MacWorkspaceSettingsModel {
         }
     }
 
+    func updateLabel(_ id: String, name: String? = nil, color: String? = nil) {
+        run { [self] in
+            try await deps.labelsApi.update(accountId: accountId, UpdateLabelInput(id: id, name: name, color: color))
+        }
+    }
+
     func deleteLabel(_ id: String) {
         run { [self] in try await deps.labelsApi.delete(accountId: accountId, id: id) }
     }
@@ -148,8 +167,12 @@ struct MacWorkspaceSettingsView: View {
 
     @State private var model: MacWorkspaceSettingsModel?
     @State private var newLabelName = ""
-    @State private var newLabelColor = "#3b82f6"
+    @State private var newLabelColor = DEFAULT_LABEL_COLOR
     @State private var agentName = MacAgentService.defaultAgentName
+    @State private var nameDraft: String?
+    @State private var editingLabelId: String?
+    @State private var editingName = ""
+    @State private var showDeleteConfirm = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -168,11 +191,24 @@ struct MacWorkspaceSettingsView: View {
                     projectsSection(model)
                     labelsSection(model)
                     agentSection()
+                    dangerSection(model)
                     if let error = model.error {
                         Text(error).foregroundStyle(.red).font(.callout)
                     }
                 }
                 .formStyle(.grouped)
+                .confirmationDialog(
+                    "Delete this workspace?",
+                    isPresented: $showDeleteConfirm,
+                    titleVisibility: .visible
+                ) {
+                    Button("Delete Workspace", role: .destructive) {
+                        model.deleteWorkspace { dismiss() }
+                    }
+                    Button("Cancel", role: .cancel) {}
+                } message: {
+                    Text("This permanently deletes the workspace and all its data.")
+                }
             } else {
                 ProgressView().frame(maxHeight: .infinity)
             }
@@ -192,6 +228,16 @@ struct MacWorkspaceSettingsView: View {
     private func generalSection(_ model: MacWorkspaceSettingsModel) -> some View {
         if let ws = model.workspace {
             Section("General") {
+                TextField("Name", text: Binding(
+                    get: { nameDraft ?? ws.name },
+                    set: { nameDraft = $0 }
+                ))
+                .textFieldStyle(.roundedBorder)
+                .disabled(!model.isOwnerOrAdmin)
+                .onSubmit {
+                    let trimmed = (nameDraft ?? "").trimmingCharacters(in: .whitespaces)
+                    if !trimmed.isEmpty, trimmed != ws.name { model.setName(trimmed) }
+                }
                 Toggle("Public workspace", isOn: Binding(
                     get: { ws.isPublic },
                     set: { model.setPublic($0) }
@@ -313,27 +359,60 @@ struct MacWorkspaceSettingsView: View {
         }
     }
 
+    @ViewBuilder
+    private func dangerSection(_ model: MacWorkspaceSettingsModel) -> some View {
+        if let ws = model.workspace, model.isOwnerOrAdmin, !ws.isPublic {
+            Section("Danger Zone") {
+                Button("Delete Workspace", role: .destructive) { showDeleteConfirm = true }
+            }
+        }
+    }
+
     private func labelsSection(_ model: MacWorkspaceSettingsModel) -> some View {
         Section("Labels") {
             ForEach(model.labels) { label in
-                HStack {
-                    Circle().fill(Color(hex: label.color) ?? .gray).frame(width: 10, height: 10)
-                    Text(label.name)
+                HStack(spacing: 10) {
+                    Menu {
+                        ColorSwatchGrid(selection: Binding(
+                            get: { label.color },
+                            set: { model.updateLabel(label.id, color: $0) }
+                        ))
+                        .padding(8)
+                        .frame(width: 200)
+                    } label: {
+                        Circle().fill(Color(hex: label.color) ?? .gray).frame(width: 14, height: 14)
+                    }
+                    .menuStyle(.borderlessButton).fixedSize()
+
+                    if editingLabelId == label.id {
+                        TextField("Name", text: $editingName)
+                            .textFieldStyle(.roundedBorder)
+                            .onSubmit {
+                                let n = editingName.trimmingCharacters(in: .whitespaces)
+                                if !n.isEmpty { model.updateLabel(label.id, name: n) }
+                                editingLabelId = nil
+                            }
+                    } else {
+                        Text(label.name)
+                            .onTapGesture { editingLabelId = label.id; editingName = label.name }
+                    }
                     Spacer()
                     Button(role: .destructive) { model.deleteLabel(label.id) } label: { Image(systemName: "trash") }
                         .buttonStyle(.borderless)
                 }
             }
-            HStack {
-                TextField("New label", text: $newLabelName).textFieldStyle(.roundedBorder)
-                TextField("#hex", text: $newLabelColor).textFieldStyle(.roundedBorder).frame(width: 90)
-                Button("Add") {
-                    let name = newLabelName.trimmingCharacters(in: .whitespaces)
-                    guard !name.isEmpty else { return }
-                    model.createLabel(name: name, color: newLabelColor)
-                    newLabelName = ""
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    TextField("New label", text: $newLabelName).textFieldStyle(.roundedBorder)
+                    Button("Add") {
+                        let name = newLabelName.trimmingCharacters(in: .whitespaces)
+                        guard !name.isEmpty else { return }
+                        model.createLabel(name: name, color: newLabelColor)
+                        newLabelName = ""
+                    }
+                    .disabled(newLabelName.trimmingCharacters(in: .whitespaces).isEmpty)
                 }
-                .disabled(newLabelName.trimmingCharacters(in: .whitespaces).isEmpty)
+                ColorSwatchGrid(selection: $newLabelColor)
             }
         }
     }

--- a/apps/ios/ExponentialMac/MacWorkspaceSettingsView.swift
+++ b/apps/ios/ExponentialMac/MacWorkspaceSettingsView.swift
@@ -258,9 +258,13 @@ struct MacWorkspaceSettingsView: View {
     }
 
     private func membersSection(_ model: MacWorkspaceSettingsModel) -> some View {
-        Section("Members") {
+        let ownerCount = model.members.filter { $0.role == DomainContract.workspaceRoleOwner }.count
+        return Section("Members") {
             ForEach(model.members) { member in
                 let u = model.user(member.userId)
+                let isSelf = member.userId == deps.auth.userId
+                // A workspace must always keep an owner — guard the last one.
+                let isLastOwner = member.role == DomainContract.workspaceRoleOwner && ownerCount <= 1
                 HStack {
                     VStack(alignment: .leading) {
                         Text(u?.name ?? u?.email ?? member.userId)
@@ -274,8 +278,15 @@ struct MacWorkspaceSettingsView: View {
                             }
                             if member.role != DomainContract.workspaceRoleMember {
                                 Button("Make member") { model.setRole(member.id, DomainContract.workspaceRoleMember) }
+                                    .disabled(isLastOwner)
                             }
-                            Button("Remove", role: .destructive) { model.removeMember(member.id) }
+                            if isSelf {
+                                if !isLastOwner {
+                                    Button("Leave workspace", role: .destructive) { model.removeMember(member.id) }
+                                }
+                            } else {
+                                Button("Remove", role: .destructive) { model.removeMember(member.id) }
+                            }
                         } label: { Image(systemName: "ellipsis.circle") }
                         .menuStyle(.borderlessButton).fixedSize()
                     }

--- a/apps/linux/src/ui/settings.zig
+++ b/apps/linux/src/ui/settings.zig
@@ -178,7 +178,12 @@ fn rebuild(ctx: *Ctx) void {
     if (std.fmt.allocPrintSentinel(a, "Members ({d})", .{members.len}, 0)) |t| {
         gtk.gtk_box_append(ctx.content, widgets.sectionTitle(t));
     } else |_| {}
-    for (members) |m| gtk.gtk_box_append(ctx.content, memberRow(ctx, a, m));
+    // A workspace must always keep at least one owner.
+    var owner_count: usize = 0;
+    for (members) |m| {
+        if (std.mem.eql(u8, m.role, "owner")) owner_count += 1;
+    }
+    for (members) |m| gtk.gtk_box_append(ctx.content, memberRow(ctx, a, m, owner_count));
 
     // --- Invites ---
     gtk.gtk_box_append(ctx.content, widgets.sectionTitle("Invites"));
@@ -786,7 +791,7 @@ fn onGhDone(data: gtk.gpointer) callconv(.c) c_int {
     return 0; // G_SOURCE_REMOVE
 }
 
-fn memberRow(ctx: *Ctx, arena: std.mem.Allocator, m: Database.MemberRow) gtk.Object {
+fn memberRow(ctx: *Ctx, arena: std.mem.Allocator, m: Database.MemberRow, owner_count: usize) gtk.Object {
     const row = gtk.gtk_box_new(gtk.ORIENTATION_HORIZONTAL, 8);
     gtk.gtk_widget_set_margin_top(row, 2);
     if (m.name.len > 0) gtk.gtk_box_append(row, widgets.avatar(arena, m.name));
@@ -816,17 +821,26 @@ fn memberRow(ctx: *Ctx, arena: std.mem.Allocator, m: Database.MemberRow) gtk.Obj
     gtk.gtk_widget_add_css_class(role_lbl, "dim-label");
     gtk.gtk_box_append(row, role_lbl);
 
-    // Agents are managed elsewhere; no actions for them.
-    if (!std.mem.eql(u8, m.role, "agent")) {
+    // Agents are managed elsewhere; no actions for them. The last owner of a
+    // workspace can't be demoted or leave (mirrors the server guard).
+    const is_last_owner = std.mem.eql(u8, m.role, "owner") and owner_count <= 1;
+    const can_make_owner = !std.mem.eql(u8, m.role, "owner");
+    const can_make_member = !std.mem.eql(u8, m.role, "member") and !is_last_owner;
+    const can_leave = is_self and !is_last_owner;
+    const can_remove = !is_self;
+    if (!std.mem.eql(u8, m.role, "agent") and (can_make_owner or can_make_member or can_leave or can_remove)) {
         const menu = gtk.gtk_menu_button_new();
         gtk.gtk_menu_button_set_child(menu, gtk.gtk_label_new("⋯"));
         const pop = gtk.gtk_popover_new();
         const list = gtk.gtk_box_new(gtk.ORIENTATION_VERTICAL, 2);
-        if (!std.mem.eql(u8, m.role, "owner"))
+        if (can_make_owner)
             addAction(ctx, list, .make_owner, m.id, "Make owner");
-        if (!std.mem.eql(u8, m.role, "member"))
+        if (can_make_member)
             addAction(ctx, list, .make_member, m.id, "Make member");
-        addAction(ctx, list, .remove_member, m.id, if (is_self) "Leave" else "Remove");
+        if (can_leave)
+            addAction(ctx, list, .remove_member, m.id, "Leave");
+        if (can_remove)
+            addAction(ctx, list, .remove_member, m.id, "Remove");
         gtk.gtk_popover_set_child(pop, list);
         gtk.gtk_menu_button_set_popover(menu, pop);
         gtk.gtk_box_append(row, menu);

--- a/apps/web/src/lib/trpc/workspace-members.ts
+++ b/apps/web/src/lib/trpc/workspace-members.ts
@@ -7,7 +7,16 @@ import {
   assertWorkspaceMember,
   assertNotPublicWorkspace,
 } from "@/lib/workspace-membership"
+import { isUserAdmin } from "@/lib/admin"
 import { revokeWorkspaceAgent } from "@/lib/companion-agents"
+
+/** Member management is allowed for a workspace owner OR a global admin. */
+async function assertCanManageMembers(userId: string, workspaceId: string) {
+  if (await isUserAdmin(userId)) {
+    return
+  }
+  await assertWorkspaceMember(userId, workspaceId, [`owner`])
+}
 
 export const workspaceMembersRouter = router({
   updateRole: authedProcedure
@@ -31,15 +40,33 @@ export const workspaceMembersRouter = router({
       await assertNotPublicWorkspace(target.workspaceId, {
         message: `Membership on the public workspace cannot be modified`,
       })
-      await assertWorkspaceMember(ctx.session.user.id, target.workspaceId, [
-        `owner`,
-      ])
+      await assertCanManageMembers(ctx.session.user.id, target.workspaceId)
 
       if (target.role === `agent`) {
         throw new TRPCError({
           code: `BAD_REQUEST`,
           message: `Agent members are managed from Agent Members`,
         })
+      }
+
+      // A workspace must always keep at least one owner — block demoting the
+      // last one (mirrors the guard in `remove`).
+      if (target.role === `owner` && input.role === `member`) {
+        const owners = await ctx.db
+          .select()
+          .from(workspaceMembers)
+          .where(
+            and(
+              eq(workspaceMembers.workspaceId, target.workspaceId),
+              eq(workspaceMembers.role, `owner`)
+            )
+          )
+        if (owners.length <= 1) {
+          throw new TRPCError({
+            code: `BAD_REQUEST`,
+            message: `Cannot demote the last owner of a workspace`,
+          })
+        }
       }
 
       const [updated] = await ctx.db
@@ -73,9 +100,7 @@ export const workspaceMembersRouter = router({
       })
 
       if (target.role === `agent`) {
-        await assertWorkspaceMember(ctx.session.user.id, target.workspaceId, [
-          `owner`,
-        ])
+        await assertCanManageMembers(ctx.session.user.id, target.workspaceId)
 
         const [agent] = await ctx.db
           .select()
@@ -101,9 +126,7 @@ export const workspaceMembersRouter = router({
 
       const isSelfRemove = target.userId === ctx.session.user.id
       if (!isSelfRemove) {
-        await assertWorkspaceMember(ctx.session.user.id, target.workspaceId, [
-          `owner`,
-        ])
+        await assertCanManageMembers(ctx.session.user.id, target.workspaceId)
       }
 
       // Prevent removing the last owner


### PR DESCRIPTION
Brings the macOS app (`apps/ios/ExponentialMac`) to web UI/UX parity, plus a cross-cutting workspace member-management bug fix that touches the server and every client. Agent/Ghostty/plan-approval is out of scope. Verified against staging (`next.exponential.at`) by building and running `Exponential-macOS-Staging`.

## 1. Shared layer (ExpCore + ExpUI) — also fixes iOS
- `TrpcClient.query` (GET): tRPC routes reads as GET, so the old POST-to-a-`.query` returned 405. Mirrors the Linux `trpc.query`.
- `AdminApi`/`IntegrationsApi` → `query` + bare-array decode → **also repairs the iOS Admin lists + Integrations status** (were 405-broken).
- New `WorkspacesApi.create`, new `ProjectsApi.create`.
- ExpUI: `StatusColor.todo` → near-white (web parity), `Accent.indigo` (#6366f1), one hoisted public `Color(hex:)` (deleted 2 dupes), shared `LABEL_COLORS` + `ColorSwatchGrid`.

## 2. macOS parity
- **Phase A:** wired admin/integrations/projects APIs; sidebar-footer identity menu (Admin / Integrations / Send feedback / Sign out); new `MacAdminView` + `MacIntegrationsView`; workspace-settings Name field + owner-only Danger-Zone delete + swatch-grid labels; indigo accent pass.
- **Phase B:** All/Active/Backlog filter tabs, per-status-group "+", recurring glyph; create-issue gained labels/recurrence/due-time-range/"Create more"; issue detail got a true right rail (`HSplitView`) in web order, recurrence + start/end time controls, and a comment timeline (relative time, "· edited", edit/delete).
- **Phase C:** create project/workspace sheets, sidebar workspace switcher, post-login `ensureDefault`, richer empty state.
- **Polish (from running it on staging):** workspace/account names written out in the sidebar (were collapsing to one letter inside a borderlessButton menu); new-issue dialog gap removed (top-aligned editor); **sidebar scoped to the active workspace** instead of flattening every workspace (web parity).

## 3. Workspace member guard — "a workspace must keep an owner" (server + all clients)
The server `workspaceMembers.updateRole` had no last-owner guard (unlike `remove`), and the native clients exposed "Make member" on yourself — so an owner could demote themselves into a zero-owner workspace and get locked out.
- **Server:** `updateRole` rejects demoting the last owner; member management now accepts workspace **owner OR global admin** (matches the native apps' gating + enables admin recovery).
- **Mac / iOS / Android / Linux:** disable/hide "Make member" for the last owner; hide "Leave" for the last-owner-self. (Android also dropped a bogus "Make agent".)

## Verification
- ✅ web typecheck; `Exponential-macOS` (arm64) + iOS `Exponential` builds; Android `assembleDebug`; `zig ast-check` on `settings.zig` (full Zig build needs Linux/GTK4).
- ✅ Ran `Exponential-macOS-Staging` against `next.exponential.at`: switcher, footer menu, workspace-scoped sidebar all confirmed.
- Note: the macOS app must build `arch=arm64` only (`libagent_core.dylib` is arm64-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)