### PR TITLE
review: web ui fixes (cmdk values, recurrence status chip, time input)

### DIFF
--- a/apps/web/src/components/create-issue-dialog.tsx
+++ b/apps/web/src/components/create-issue-dialog.tsx
@@ -451,8 +451,9 @@ export function CreateIssueDialog({
         uploading: submitPhase === `uploading`,
         onFiles: handleImageFiles,
       }}
-      status={status}
+      status={recurrence ? `todo` : status}
       onStatusChange={setStatus}
+      disableStatus={recurrence !== null}
       priority={priority}
       onPriorityChange={setPriority}
       workspaceId={workspaceId}

--- a/apps/web/src/components/issue-editor/chips.tsx
+++ b/apps/web/src/components/issue-editor/chips.tsx
@@ -42,6 +42,7 @@ export interface IssueEditorChipsProps {
   endTime: string | null
   hideAssignee?: boolean
   hideDueDateChip?: boolean
+  disableStatus?: boolean
   disabled?: boolean
   moderationDisabled?: boolean
   chipRowExtras?: ReactNode
@@ -67,6 +68,7 @@ export function IssueEditorChips({
   endTime,
   hideAssignee,
   hideDueDateChip,
+  disableStatus,
   disabled,
   moderationDisabled,
   chipRowExtras,
@@ -83,7 +85,7 @@ export function IssueEditorChips({
     <>
       <OptionDropdownMenu
         value={status}
-        disabled={moderationDisabled}
+        disabled={moderationDisabled || disableStatus}
         options={creatableStatuses}
         onSelect={onStatusChange}
         mobileTitle="Status"
@@ -92,7 +94,7 @@ export function IssueEditorChips({
             variant="ghost"
             size="xs"
             className="text-muted-foreground shrink-0"
-            disabled={moderationDisabled}
+            disabled={moderationDisabled || disableStatus}
           >
             <StatusIcon status={selected.value} className="!h-3 !w-3" />
             {selected.label}

--- a/apps/web/src/components/issue-editor/dialog-shell.tsx
+++ b/apps/web/src/components/issue-editor/dialog-shell.tsx
@@ -55,6 +55,7 @@ interface IssueEditorDialogShellProps {
   chipRowExtras?: ReactNode
   hideAssignee?: boolean
   hideDueDateChip?: boolean
+  disableStatus?: boolean
   imageUpload?: MarkdownEditorImageUploadConfig
   overflowMenuItems?: ReactNode
   onAssigneeChange: (userId: string | null) => void | Promise<void>
@@ -100,6 +101,7 @@ export function IssueEditorDialogShell({
   headerContent,
   hideAssignee,
   hideDueDateChip,
+  disableStatus,
   imageUpload,
   overflowMenuItems,
   onAssigneeChange,
@@ -206,6 +208,7 @@ export function IssueEditorDialogShell({
       endTime={endTime}
       hideAssignee={hideAssignee}
       hideDueDateChip={hideDueDateChip}
+      disableStatus={disableStatus}
       disabled={disabled}
       moderationDisabled={moderationDisabled}
       chipRowExtras={chipRowExtras}

--- a/apps/web/src/components/issue-filter-popover.tsx
+++ b/apps/web/src/components/issue-filter-popover.tsx
@@ -194,7 +194,8 @@ function LabelsView({
           {labels.map((label) => (
             <CommandItem
               key={label.id}
-              value={label.name}
+              value={label.id}
+              keywords={[label.name]}
               onSelect={() => onToggle(label.id)}
               className="flex items-center gap-2"
             >

--- a/apps/web/src/components/issue-properties/assignee-dropdown.tsx
+++ b/apps/web/src/components/issue-properties/assignee-dropdown.tsx
@@ -75,7 +75,8 @@ export function AssigneeDropdown({
   const renderUser = (user: User) => (
     <CommandItem
       key={user.id}
-      value={user.name}
+      value={user.id}
+      keywords={[user.name]}
       onSelect={() => handleSelect(user.id)}
       className="flex items-center gap-2"
     >

--- a/apps/web/src/components/issue-properties/assignee-picker.tsx
+++ b/apps/web/src/components/issue-properties/assignee-picker.tsx
@@ -106,7 +106,8 @@ export function AssigneePicker({
               {users.map((user) => (
                 <CommandItem
                   key={user.id}
-                  value={user.name}
+                  value={user.id}
+                  keywords={[user.name]}
                   onSelect={() => {
                     onSelect(user.id)
                     setOpen(false)

--- a/apps/web/src/components/issue-properties/label-picker.tsx
+++ b/apps/web/src/components/issue-properties/label-picker.tsx
@@ -136,7 +136,8 @@ export function LabelPicker({
                   return (
                     <CommandItem
                       key={label.id}
-                      value={label.name}
+                      value={label.id}
+                      keywords={[label.name]}
                       onSelect={() => onToggle(label.id)}
                       className="flex items-center gap-2"
                     >

--- a/apps/web/src/components/issue-properties/release-picker.tsx
+++ b/apps/web/src/components/issue-properties/release-picker.tsx
@@ -100,7 +100,8 @@ export function ReleasePicker({
               {releases.map((release) => (
                 <CommandItem
                   key={release.id}
-                  value={release.name}
+                  value={release.id}
+                  keywords={[release.name]}
                   onSelect={() => handlePick(release.id)}
                   className="flex items-center gap-2"
                 >

--- a/apps/web/src/components/time-input.test.tsx
+++ b/apps/web/src/components/time-input.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { TimeInput } from "@/components/time-input"
+
+function renderInput(value: string | null = null) {
+  const onChange = vi.fn()
+  render(
+    <TimeInput value={value} onChange={onChange} ariaLabel="Start time" />
+  )
+  const input = screen.getByLabelText(`Start time`) as HTMLInputElement
+  return { input, onChange }
+}
+
+function commit(input: HTMLInputElement, raw: string) {
+  fireEvent.change(input, { target: { value: raw } })
+  fireEvent.blur(input)
+}
+
+describe(`TimeInput commit parsing`, () => {
+  it.each([
+    [`9:5`, `09:05`],
+    [`9:`, `09:00`],
+    [`9`, `09:00`],
+    [`13`, `13:00`],
+    [`13:37`, `13:37`],
+    [`1337`, `13:37`],
+    [`930`, `09:30`],
+  ])(`normalizes %s to %s`, (raw, expected) => {
+    const { input, onChange } = renderInput()
+    commit(input, raw)
+    expect(onChange).toHaveBeenCalledWith(expected)
+    expect(input.value).toBe(expected)
+  })
+
+  it(`clears to null on an empty entry`, () => {
+    const { input, onChange } = renderInput(`08:30`)
+    commit(input, ``)
+    expect(onChange).toHaveBeenCalledWith(null)
+    expect(input.value).toBe(``)
+  })
+
+  it.each([`25:00`, `12:75`, `9:99`])(
+    `reverts invalid entry %s to the prior value`,
+    (raw) => {
+      const { input, onChange } = renderInput(`08:30`)
+      commit(input, raw)
+      expect(onChange).not.toHaveBeenCalled()
+      expect(input.value).toBe(`08:30`)
+    }
+  )
+})

--- a/apps/web/src/components/time-input.tsx
+++ b/apps/web/src/components/time-input.tsx
@@ -11,10 +11,10 @@ interface TimeInputProps {
 
 /**
  * Compact HH:MM input. Lets the user type freely — "1337", "13:37",
- * "9:5" all become "13:37" / "09:05" on commit. Native <input type="time">
- * forces a segmented cursor and an OS-level picker that fights typed entry,
- * so we use a plain text field with a digit-only pattern and parse on
- * blur / Enter.
+ * "9:5" all become "13:37" / "09:05", and a bare "9" becomes "09:00" on
+ * commit. Native <input type="time"> forces a segmented cursor and an
+ * OS-level picker that fights typed entry, so we use a plain text field
+ * with a digit-only pattern and parse on blur / Enter.
  */
 export function TimeInput({
   value,
@@ -38,18 +38,41 @@ export function TimeInput({
       return
     }
 
-    const digits = trimmed.replace(/\D/g, ``)
-    if (digits.length < 3 || digits.length > 4) {
-      setDraft(value ? value.slice(0, 5) : ``)
-      return
+    const revert = () => setDraft(value ? value.slice(0, 5) : ``)
+
+    let hh: string
+    let mm: string
+    if (trimmed.includes(`:`)) {
+      // "9:5" → 09:05, "9:" → 09:00 — hours and minutes parse independently
+      // (1-2 digits each), so we never need three digits before the colon.
+      const [rawHours, rawMinutes = ``] = trimmed.split(`:`)
+      hh = rawHours.replace(/\D/g, ``)
+      const minutes = rawMinutes.replace(/\D/g, ``)
+      if (hh.length < 1 || hh.length > 2 || minutes.length > 2) {
+        revert()
+        return
+      }
+      mm = minutes || `0`
+    } else {
+      // Colon-less entry: "1337" → 13:37, bare "9" → 09:00.
+      const digits = trimmed.replace(/\D/g, ``)
+      if (digits.length < 1 || digits.length > 4) {
+        revert()
+        return
+      }
+      if (digits.length <= 2) {
+        hh = digits
+        mm = `0`
+      } else {
+        hh = digits.length === 3 ? digits.slice(0, 1) : digits.slice(0, 2)
+        mm = digits.slice(digits.length === 3 ? 1 : 2)
+      }
     }
 
-    const hh = digits.length === 3 ? digits.slice(0, 1) : digits.slice(0, 2)
-    const mm = digits.length === 3 ? digits.slice(1) : digits.slice(2)
     const h = Number(hh)
     const m = Number(mm)
     if (h > 23 || m > 59) {
-      setDraft(value ? value.slice(0, 5) : ``)
+      revert()
       return
     }
 


### PR DESCRIPTION
Fixes 3 verified findings from the 2026-07-10 review, web UI batch:

- REV-70 cmdk pickers use stable ids as CommandItem values (+`keywords` for type-to-search) so duplicate member/label names no longer collide — assignee dropdown/picker, label picker, filter popover, release picker
- REV-71 create-issue dialog: when recurrence is enabled the status chip shows `todo` and is disabled, matching what is actually submitted
- REV-72 TimeInput accepts the forms its doc promises (`9`, `9:5`, `9:` …) via colon-aware parsing; new 11-case unit test

Verification: `bun run typecheck` clean; `bun run test` 664 pass (incl. new time-input suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)