### PR TITLE
review: relay fixes (resize re-hello, viewer eviction, XFF trust, dead codes, body caps)

### DIFF
--- a/apps/push-relay/src/index.ts
+++ b/apps/push-relay/src/index.ts
@@ -126,11 +126,49 @@ function clientIp(headers: Headers, fallback = `unknown`): string {
   return fallback
 }
 
-// ── Dead-token error codes per Firebase docs ──────────────────────────────────
+// Read a request body with a hard byte cap, aborting the stream as soon as it
+// exceeds the cap. Returns null when over the cap; a read error yields an
+// empty string (which then fails JSON parsing as before).
+async function readBodyCapped(
+  body: ReadableStream<Uint8Array> | null,
+  maxBytes: number
+): Promise<string | null> {
+  if (!body) return ``
+  const reader = body.getReader()
+  const chunks: Uint8Array[] = []
+  let total = 0
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      total += value.byteLength
+      if (total > maxBytes) {
+        await reader.cancel().catch(() => {})
+        return null
+      }
+      chunks.push(value)
+    }
+  } catch {
+    return ``
+  }
+  return Buffer.concat(chunks).toString(`utf8`)
+}
+
+// ── Dead-token error codes ────────────────────────────────────────────────────
+// Codes the FCM v1 path (sendEachForMulticast) can actually emit for a token
+// that is PERMANENTLY undeliverable and must be pruned:
+//   - registration-token-not-registered: v1 UNREGISTERED, the canonical
+//     dead-token code.
+//   - mismatched-credential: v1 SENDER_ID_MISMATCH — the token belongs to a
+//     different Firebase project and will never work with our credential.
+// Deliberately absent: invalid-argument (also fired for malformed payloads —
+// pruning on it would mass-delete valid tokens on a payload bug) and
+// invalid-registration-token (legacy-API-only; the v1 endpoint never maps to
+// it, so listing it was dead weight).
 
 const DEAD_CODES = new Set([
   `messaging/registration-token-not-registered`,
-  `messaging/invalid-registration-token`,
+  `messaging/mismatched-credential`,
 ])
 
 // ── Hono app ──────────────────────────────────────────────────────────────────
@@ -153,7 +191,7 @@ app.post(`/send`, async (c) => {
   }
 
   // Reject oversized bodies before parsing JSON — the relay only ever needs
-  // tokens + a short notification.
+  // tokens + a short notification. Cheap pre-check on the declared length…
   const contentLength = Number.parseInt(
     c.req.raw.headers.get(`content-length`) ?? `0`,
     10
@@ -167,8 +205,11 @@ app.post(`/send`, async (c) => {
     return c.json({ error: `Firebase not configured` }, 503)
   }
 
-  const rawText = await c.req.text().catch(() => ``)
-  if (rawText.length > MAX_BODY_BYTES) {
+  // …then a size-capped streaming read: a chunked request carries no
+  // Content-Length, so reading the stream and aborting past the cap is the
+  // only way to avoid buffering an unbounded body into memory.
+  const rawText = await readBodyCapped(c.req.raw.body, MAX_BODY_BYTES)
+  if (rawText === null) {
     return c.json({ error: `Body too large` }, 413)
   }
   const body = (() => {

--- a/apps/steer-relay/src/hub.test.ts
+++ b/apps/steer-relay/src/hub.test.ts
@@ -314,6 +314,38 @@ describe(`session rooms`, () => {
     ).toBe(`resumed`)
   })
 
+  test(`re-hello with changed geometry broadcasts resize to attached viewers`, () => {
+    const hub = new Hub()
+    const pub = connectPublisher(hub) // 120x40
+    const viewer = connectViewer(hub)
+    const pv = connectPublicViewer(hub)
+    expect(viewer.lastFrame(`resize`)).toMatchObject({ cols: 120, rows: 40 })
+
+    // Publisher drops, gets resized while disconnected, re-hellos at 80x24.
+    hub.onClose(pub)
+    const pub2 = new FakeSocket()
+    hub.onOpen(pub2, claims({ role: `publisher`, sessionId: `sess-1`, perm: `view` }))
+    hub.onMessage(
+      pub2,
+      JSON.stringify({ t: `hello`, sessionId: `sess-1`, cols: 80, rows: 24 })
+    )
+    expect(viewer.lastFrame(`resize`)).toMatchObject({ cols: 80, rows: 24 })
+    // The anonymous activity audience never receives geometry.
+    expect(pv.lastFrame(`resize`)).toBeUndefined()
+
+    // A same-geometry re-hello stays quiet.
+    const resizes = () => viewer.frames().filter((f) => f.t === `resize`).length
+    const before = resizes()
+    hub.onClose(pub2)
+    const pub3 = new FakeSocket()
+    hub.onOpen(pub3, claims({ role: `publisher`, sessionId: `sess-1`, perm: `view` }))
+    hub.onMessage(
+      pub3,
+      JSON.stringify({ t: `hello`, sessionId: `sess-1`, cols: 80, rows: 24 })
+    )
+    expect(resizes()).toBe(before)
+  })
+
   test(`slow consumer gets frames dropped, then a resync on recovery`, () => {
     const hub = new Hub()
     const pub = connectPublisher(hub)
@@ -545,6 +577,31 @@ describe(`member activity channel (EXP-32)`, () => {
       { userId: `w`, name: `Viewer`, perm: `view` },
     ])
     expect(watcher.lastFrame(`presence`)).toMatchObject({ steererId: null })
+  })
+
+  test(`disconnect evicts a socket that joined BOTH the pty and activity channels`, () => {
+    const hub = new Hub()
+    const pub = connectPublisher(hub)
+    const dual = connectViewer(hub, { sub: `dual`, name: `Dual` })
+    hub.onMessage(dual, JSON.stringify({ t: `join`, channel: `activity` }))
+    // The socket now sits in both audiences; presence lists it twice.
+    expect(pub.lastFrame(`presence`)?.viewers).toEqual([
+      { userId: `dual`, name: `Dual`, perm: `steer` },
+      { userId: `dual`, name: `Dual`, perm: `steer` },
+    ])
+
+    hub.onClose(dual)
+    // No ghost entry survives in either map.
+    expect(pub.lastFrame(`presence`)?.viewers).toEqual([])
+
+    // Activity frames after the disconnect no longer reach the dead socket.
+    const sentBefore = dual.sent.length
+    hub.onMessage(
+      pub,
+      JSON.stringify({ t: `activity`, event: { kind: `narration`, text: `after` } })
+    )
+    output(hub, pub, `after`)
+    expect(dual.sent.length).toBe(sentBefore)
   })
 
   test(`room close sends bye to activity members and evicts them`, () => {

--- a/apps/steer-relay/src/hub.ts
+++ b/apps/steer-relay/src/hub.ts
@@ -180,12 +180,15 @@ export class Hub {
       room.staleTimer ??= setTimeout(() => {
         this.closeRoom(room, `publisher_lost`)
       }, PUBLISHER_GRACE_MS)
-    } else if (room.viewers.has(conn)) {
-      room.viewers.delete(conn)
-      if (room.steerer === conn) room.steerer = null
-      this.broadcastPresence(room)
-    } else if (room.activityMembers.has(conn)) {
-      room.activityMembers.delete(conn)
+      return
+    }
+
+    // One socket may sit in BOTH audiences (a viewer ticket can join the pty
+    // channel and the activity channel), so the evictions must be independent
+    // — an else-if here would leave a ghost Conn in the other map.
+    const wasViewer = room.viewers.delete(conn)
+    const wasActivityMember = room.activityMembers.delete(conn)
+    if (wasViewer || wasActivityMember) {
       if (room.steerer === conn) room.steerer = null
       this.broadcastPresence(room)
     }
@@ -251,8 +254,21 @@ export class Hub {
             room.publisher.sock.close(CLOSE_REPLACED, `replaced`)
           }
           room.publisher = conn
+          // The re-hello carries the publisher's TRUE current geometry — it
+          // may have been resized while disconnected, so already-attached
+          // viewers need a resize frame or they keep rendering the stale grid.
+          const geometryChanged =
+            (!!msg.cols && msg.cols !== room.cols) ||
+            (!!msg.rows && msg.rows !== room.rows)
           if (msg.cols) room.cols = msg.cols
           if (msg.rows) room.rows = msg.rows
+          if (geometryChanged) {
+            for (const viewer of room.viewers.keys()) {
+              viewer.sock.send(
+                frame({ t: `resize`, cols: room.cols, rows: room.rows })
+              )
+            }
+          }
           room.activityPublic = msg.activityPublic ?? true
         }
         this.broadcastPresence(room)

--- a/apps/steer-relay/src/index.ts
+++ b/apps/steer-relay/src/index.ts
@@ -11,6 +11,7 @@
 // refuses connections (503) — the web app equally treats the subsystem as off
 // when STEER_RELAY_URL is unset.
 
+import { timingSafeEqual } from "node:crypto"
 import { Hono } from "hono"
 import type { ServerWebSocket } from "bun"
 import { verifySteerTicket, type SteerTicketClaims } from "@exp/steer-ticket"
@@ -56,14 +57,35 @@ setInterval(() => {
   }
 }, RATE_LIMIT_WINDOW_MS).unref?.()
 
+// Forwarded headers are client-forgeable: every spoofed value would mint its
+// own fresh rate-limit bucket. They are honored only when TRUST_PROXY says a
+// reverse proxy we control fronts the relay — and then only the RIGHTMOST
+// x-forwarded-for entry (the one that proxy appended) counts. Otherwise all
+// requests share the fallback bucket.
+const TRUST_PROXY = process.env.TRUST_PROXY === `true`
+
+// Loose IPv4/IPv6 shape check — anything else falls back to the shared bucket.
 const IP_RE = /^(?:\d{1,3}(?:\.\d{1,3}){3}|[0-9a-fA-F:]+)$/
 
 function clientIp(headers: Headers, fallback = `unknown`): string {
-  const forwarded = headers.get(`x-forwarded-for`)
-  const candidate =
-    forwarded?.split(`,`)[0]!.trim() || headers.get(`x-real-ip`)?.trim()
+  if (!TRUST_PROXY) return fallback
+  const forwarded = headers
+    .get(`x-forwarded-for`)
+    ?.split(`,`)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+  const candidate = forwarded?.at(-1) ?? headers.get(`x-real-ip`)?.trim()
   if (candidate && IP_RE.test(candidate)) return candidate
   return fallback
+}
+
+// Constant-time secret check — a plain string compare leaks length and
+// prefix-match timing on the single shared credential.
+function secretMatches(provided: string | null): boolean {
+  if (!provided || !RELAY_SECRET) return false
+  const a = Buffer.from(provided)
+  const b = Buffer.from(RELAY_SECRET)
+  return a.length === b.length && timingSafeEqual(a, b)
 }
 
 // ── HTTP app (health + secret-authed server-to-server endpoints) ──────────────
@@ -76,7 +98,7 @@ app.get(`/healthz`, (c) => c.json({ ok: true, ...hub.stats() }))
 app.use(`*`, async (c, next) => {
   if (c.req.path === `/healthz`) return next()
   if (!RELAY_SECRET) return c.json({ error: `Relay not configured` }, 503)
-  if (c.req.raw.headers.get(`x-relay-secret`) !== RELAY_SECRET) {
+  if (!secretMatches(c.req.raw.headers.get(`x-relay-secret`))) {
     return c.json({ error: `Unauthorized` }, 401)
   }
   return next()


### PR DESCRIPTION
Fixes 6 verified findings from the 2026-07-10 review, relay batch:

Steer relay:
- REV-49 publisher re-hello with changed geometry now broadcasts a resize frame to attached viewers (+tests)
- REV-90 disconnect evicts a socket from BOTH viewers and activityMembers (no ghost presence; +test)
- REV-91/100 clientIp honors forwarded headers only with `TRUST_PROXY=true` and then takes the rightmost XFF hop (ported from the push relay)
- x-relay-secret compare switched to length-checked `crypto.timingSafeEqual` (same hardening the push relay got)

Push relay:
- REV-93 DEAD_CODES aligned with what firebase-admin v13 actually emits on the v1 path: `messaging/registration-token-not-registered` + `messaging/mismatched-credential`; legacy `invalid-registration-token` dropped; `invalid-argument` deliberately NOT pruned (fires on malformed payloads)
- REV-95 residual: body read via a size-capped streaming reader (64KiB → 413), so chunked bodies can't buffer unbounded

Verification: `bun run test:steer-relay` 34+5 pass; both relays typecheck clean.

Deploy note: set `TRUST_PROXY=true` on the Coolify steer-relay apps (prod + staging) when this ships — Traefik fronts them; without it all clients share one rate-limit bucket (safe default, but coarse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)