### PR TITLE
review: native quick wins (iOS due colors, desktop editor guard, is_protected, session gate)

### DIFF
--- a/apps/desktop/crates/domain/src/rows.rs
+++ b/apps/desktop/crates/domain/src/rows.rs
@@ -78,6 +78,11 @@ pub struct Project {
     /// `off` / `badge` / `live` — raw wire value (contract-locked).
     #[serde(default)]
     pub public_show_coding: Option<String>,
+    /// Trash contract: protected projects (the bootstrap dogfood board) are
+    /// non-deletable/non-archivable/non-retypable — the server refuses, and
+    /// clients disable the affordances from this flag. `None` on legacy rows.
+    #[serde(default, deserialize_with = "tolerant_opt_bool")]
+    pub is_protected: Option<bool>,
     #[serde(default, deserialize_with = "tolerant_opt_f64")]
     pub sort_order: Option<f64>,
     #[serde(default)]

--- a/apps/desktop/crates/sync/src/shapes.rs
+++ b/apps/desktop/crates/sync/src/shapes.rs
@@ -118,6 +118,9 @@ pub const SHAPES: [ShapeSpec; 15] = [
             "public_show_comments",
             "public_show_activity",
             "public_show_coding",
+            // Trash contract: the bootstrap dogfood project is protected —
+            // clients disable delete/archive/retype from this synced flag.
+            "is_protected",
             "sort_order",
             "archived_at",
             "created_at",

--- a/apps/desktop/crates/ui/src/description_editor.rs
+++ b/apps/desktop/crates/ui/src/description_editor.rs
@@ -150,6 +150,10 @@ impl DescriptionEditor for SeamEditor {
         self.current.borrow().clone()
     }
 
+    fn is_focused(&self, window: &Window, cx: &App) -> bool {
+        self.editor.read(cx).is_focused(window, cx)
+    }
+
     fn element(&self, _window: &mut Window, _cx: &mut App) -> gpui::AnyElement {
         self.editor.clone().into_any_element()
     }

--- a/apps/desktop/crates/ui/src/issue_changes.rs
+++ b/apps/desktop/crates/ui/src/issue_changes.rs
@@ -520,10 +520,19 @@ impl IssueChanges {
                 .dropdown_menu(move |mut menu, _, _| {
                     if let Some(repo) = repo.clone() {
                         // Update from main → a Claude task in the worktree (§4.9).
+                        // Blocked while a session runs: a second `claude` in the
+                        // same worktree would supersede the session transcript
+                        // the public-activity emitter tails.
                         let settings = settings.clone();
                         let identifier = identifier.clone();
                         let update_repo = repo.clone();
-                        menu = menu.item(
+                        let item = if running {
+                            PopupMenuItem::new(
+                                "Update from main — stop the running session first",
+                            )
+                            .icon(Icon::from(ExpIcon::Repeat))
+                            .disabled(true)
+                        } else {
                             PopupMenuItem::new("Update from main")
                                 .icon(Icon::from(ExpIcon::Repeat))
                                 .on_click(move |_, window, cx| {
@@ -534,8 +543,9 @@ impl IssueChanges {
                                         window,
                                         cx,
                                     );
-                                }),
-                        );
+                                })
+                        };
+                        menu = menu.item(item);
 
                         if show_cleanup {
                             let weak = weak.clone();

--- a/apps/desktop/crates/ui/src/issue_detail.rs
+++ b/apps/desktop/crates/ui/src/issue_detail.rs
@@ -98,6 +98,9 @@ pub trait DescriptionEditor {
     fn set_markdown(&self, markdown: &str, window: &mut Window, cx: &mut App);
     /// Current GFM source.
     fn markdown(&self, cx: &App) -> String;
+    /// Whether the editor currently owns keyboard focus (the user is
+    /// mid-edit) — remote echoes must not rebuild the buffer under them.
+    fn is_focused(&self, window: &Window, cx: &App) -> bool;
     /// The element to mount in the description slot.
     fn element(&self, window: &mut Window, cx: &mut App) -> gpui::AnyElement;
     /// Move keyboard focus into the editor (Tab from the title lands here —
@@ -378,14 +381,22 @@ impl IssueDetailView {
         }
 
         // Description: build the editor when the seam is filled, then forward
-        // echoes.
+        // echoes. Skipped while the editor owns focus (same rule as the
+        // title) — `last_saved_description` stays stale on purpose so the
+        // next non-focused sync still applies the remote text.
         self.ensure_editor(&issue, window, cx);
         let incoming = issue.description.clone().unwrap_or_default();
         let normalized = incoming.trim().to_string();
         if normalized != *self.last_saved_description.borrow() {
-            *self.last_saved_description.borrow_mut() = normalized;
-            if let Some(editor) = self.editor.clone() {
-                editor.set_markdown(&incoming, window, cx);
+            let focused = self
+                .editor
+                .as_ref()
+                .is_some_and(|editor| editor.is_focused(window, cx));
+            if !focused {
+                *self.last_saved_description.borrow_mut() = normalized;
+                if let Some(editor) = self.editor.clone() {
+                    editor.set_markdown(&incoming, window, cx);
+                }
             }
         }
     }

--- a/apps/desktop/crates/ui/src/markdown/editor.rs
+++ b/apps/desktop/crates/ui/src/markdown/editor.rs
@@ -26,7 +26,8 @@ use std::sync::Arc;
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
     canvas, deferred, div, img, point, px, App, AppContext as _, Bounds, ClipboardEntry, Context,
-    ElementId, Entity, FontStyle, FontWeight, HighlightStyle, InteractiveElement as _,
+    ElementId, Entity, Focusable as _, FontStyle, FontWeight, HighlightStyle,
+    InteractiveElement as _,
     InteractiveText, IntoElement, ParentElement as _, Pixels, Render, SharedString,
     StatefulInteractiveElement as _, StrikethroughStyle, Styled as _, StyledImage as _, StyledText,
     Subscription, TextRun, UnderlineStyle, Window,
@@ -472,6 +473,15 @@ impl MarkdownEditor {
 
     pub fn is_uploading(&self) -> bool {
         self.uploads_in_flight > 0
+    }
+
+    /// Whether any text block currently owns keyboard focus (the user is
+    /// mid-edit).
+    pub fn is_focused(&self, window: &Window, cx: &App) -> bool {
+        self.blocks.iter().any(|block| match block {
+            EditorBlock::Text { input, .. } => input.read(cx).focus_handle(cx).is_focused(window),
+            _ => false,
+        })
     }
 
     /// Focus the last text block (append position).

--- a/apps/desktop/crates/ui/src/settings/projects.rs
+++ b/apps/desktop/crates/ui/src/settings/projects.rs
@@ -15,7 +15,7 @@ use gpui::{
 use gpui_component::{
     button::{Button, ButtonVariant, ButtonVariants as _},
     dialog::DialogButtonProps,
-    h_flex, v_flex, ActiveTheme as _, IconName, Sizable as _, WindowExt as _,
+    h_flex, v_flex, ActiveTheme as _, Disableable as _, IconName, Sizable as _, WindowExt as _,
 };
 use sync::Store;
 
@@ -122,6 +122,26 @@ impl Render for ProjectsPane {
                 let prefix: SharedString = project.prefix.clone().unwrap_or_default().into();
                 let project_id = project.id.clone();
                 let project_name = project.name.clone();
+                // Protected projects (the bootstrap dogfood board) are
+                // non-deletable — the server refuses, so grey out the
+                // affordance from the synced flag like the other clients.
+                let protected = project.is_protected.unwrap_or(false);
+                let delete_button = Button::new(row_id("project-delete", &project.id))
+                    .ghost()
+                    .xsmall()
+                    .icon(IconName::Delete);
+                let delete_button = if protected {
+                    delete_button.disabled(true)
+                } else {
+                    delete_button.on_click(cx.listener(move |_, _, window, cx| {
+                        Self::open_delete_dialog(
+                            project_id.clone(),
+                            project_name.clone(),
+                            window,
+                            cx,
+                        );
+                    }))
+                };
 
                 list = list.child(
                     h_flex()
@@ -156,20 +176,7 @@ impl Render for ProjectsPane {
                                 .text_color(cx.theme().muted_foreground)
                                 .child(prefix),
                         )
-                        .child(
-                            Button::new(row_id("project-delete", &project.id))
-                                .ghost()
-                                .xsmall()
-                                .icon(IconName::Delete)
-                                .on_click(cx.listener(move |_, _, window, cx| {
-                                    Self::open_delete_dialog(
-                                        project_id.clone(),
-                                        project_name.clone(),
-                                        window,
-                                        cx,
-                                    );
-                                })),
-                        ),
+                        .child(delete_button),
                 );
             }
             body = body.child(list);

--- a/apps/ios/Exponential/UI/Issue/IssueListView.swift
+++ b/apps/ios/Exponential/UI/Issue/IssueListView.swift
@@ -439,8 +439,9 @@ struct IssueListView: View {
 
     private func dueDateColor(_ dateString: String) -> Color {
         guard let date = AppDateFormatters.yyyyMMdd.date(from: dateString) else { return .white.opacity(TextOpacity.tertiary) }
-        if date < Date() { return DesignTokens.Semantic.red }
+        // Due-today must win over overdue: the date parses to local midnight, which is already past.
         if Calendar.current.isDateInToday(date) { return DesignTokens.Semantic.orange }
+        if date < Date() { return DesignTokens.Semantic.red }
         return .white.opacity(TextOpacity.tertiary)
     }
 }

--- a/apps/ios/Exponential/UI/MyIssues/MyIssuesView.swift
+++ b/apps/ios/Exponential/UI/MyIssues/MyIssuesView.swift
@@ -169,8 +169,9 @@ struct MyIssuesListContent: View {
         guard let date = AppDateFormatters.yyyyMMdd.date(from: dateString) else {
             return .white.opacity(TextOpacity.tertiary)
         }
-        if date < Date() { return DesignTokens.Semantic.red }
+        // Due-today must win over overdue: the date parses to local midnight, which is already past.
         if Calendar.current.isDateInToday(date) { return DesignTokens.Semantic.orange }
+        if date < Date() { return DesignTokens.Semantic.red }
         return .white.opacity(TextOpacity.tertiary)
     }
 }


### PR DESCRIPTION
Fixes 4 verified findings from the 2026-07-10 review, native batch:

- REV-98 (iOS) due-today renders orange instead of overdue-red: `isDateInToday` now checked before the overdue comparison in IssueListView + MyIssuesView (not compiled here — needs a Mac build before release)
- REV-45 (desktop) remote description echoes no longer wipe mid-edit text: sync skips `set_markdown` while the description editor owns focus (mirrors the title guard); next non-focused sync applies the remote text
- REV-97 (desktop) `is_protected` now synced on the projects shape (local sqlite self-heals the column) and the Delete affordance is disabled for protected projects — restores client parity with web/iOS/Android
- REV-92 (desktop, minimal gate) "Update from main" is disabled while a session is running, so a second claude can't supersede the transcript the public-activity emitter tails

Verification: `cargo check --workspace` green; `cargo test -p domain -p sync -p ui` 262 pass. Swift edits are surgical two-line swaps, uncompiled on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)