### PR TITLE
reviews: show all open PRs, including ones not linked to issues

### DIFF
--- a/apps/web/src/hooks/use-reviews-data.ts
+++ b/apps/web/src/hooks/use-reviews-data.ts
@@ -1,15 +1,23 @@
-import { useMemo } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { and, eq, inArray, useLiveQuery } from "@tanstack/react-db"
 import { issueCollection } from "@/lib/collections"
 import {
   useWorkspaceProjects,
   useWorkspaceUsers,
 } from "@/hooks/use-workspace-data"
+import { trpc } from "@/lib/trpc-client"
+import type { OpenPull } from "@/lib/integrations/github-pr"
 import type { Issue, Project, Workspace } from "@/db/schema"
 
 export interface ReviewGroup {
   project: Project
   issues: Issue[]
+}
+
+export interface ExternalPullGroup {
+  repositoryId: string
+  fullName: string
+  pulls: OpenPull[]
 }
 
 // Cross-project review queue: every issue in the workspace with an open pull
@@ -41,6 +49,53 @@ export function useReviewsData(workspace: Workspace | null | undefined) {
 
   const { userMap } = useWorkspaceUsers(workspace?.id)
 
+  // Open PRs with no issue link, fetched live from GitHub through the server
+  // (they have no synced row to live-query). Failures degrade to an empty
+  // list — the issue-linked queue still renders.
+  const [externalGroups, setExternalGroups] = useState<ExternalPullGroup[]>([])
+  const [externalLoading, setExternalLoading] = useState(false)
+  const workspaceId = workspace?.id
+  useEffect(() => {
+    if (!workspaceId) return
+    let cancelled = false
+    setExternalLoading(true)
+    trpc.repositories.openPulls
+      .query({ workspaceId })
+      .then((result) => {
+        if (cancelled) return
+        setExternalGroups(result.repos.filter((repo) => repo.pulls.length > 0))
+      })
+      .catch(() => {
+        if (!cancelled) setExternalGroups([])
+      })
+      .finally(() => {
+        if (!cancelled) setExternalLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [workspaceId])
+
+  // External PRs have no Electric echo — a successful merge removes the row
+  // locally.
+  const removeExternalPull = useCallback(
+    (repositoryId: string, prNumber: number) => {
+      setExternalGroups((groups) =>
+        groups
+          .map((group) =>
+            group.repositoryId === repositoryId
+              ? {
+                  ...group,
+                  pulls: group.pulls.filter((pull) => pull.number !== prNumber),
+                }
+              : group
+          )
+          .filter((group) => group.pulls.length > 0)
+      )
+    },
+    []
+  )
+
   return useMemo(() => {
     const list = (issues ?? []) as Issue[]
     const byProject = new Map<string, Issue[]>()
@@ -65,13 +120,31 @@ export function useReviewsData(workspace: Workspace | null | undefined) {
       groups.push({ project, issues: bucket })
     }
 
+    const externalCount = externalGroups.reduce(
+      (sum, group) => sum + group.pulls.length,
+      0
+    )
+
     return {
       groups,
-      count: list.length,
+      externalGroups,
+      count: list.length + externalCount,
       // A workspace with no projects skips the query and can never deliver a
-      // snapshot — treat it as ready-empty instead of loading forever.
+      // snapshot — treat it as ready-empty instead of loading forever. The
+      // external fetch has its own flag so the synced queue renders without
+      // waiting on GitHub.
       isLoading: !isReady && projects.length > 0,
+      externalLoading,
       userMap,
+      removeExternalPull,
     }
-  }, [issues, isReady, projects, userMap])
+  }, [
+    issues,
+    isReady,
+    projects,
+    userMap,
+    externalGroups,
+    externalLoading,
+    removeExternalPull,
+  ])
 }

--- a/apps/web/src/lib/integrations/github-pr.ts
+++ b/apps/web/src/lib/integrations/github-pr.ts
@@ -147,6 +147,58 @@ export async function fetchPullState(
   }
 }
 
+export interface OpenPull {
+  number: number
+  url: string
+  title: string
+  branch: string
+  baseBranch: string
+  draft: boolean
+  authorLogin: string | null
+  authorAvatarUrl: string | null
+  createdAt: string
+}
+
+// List a repository's open pull requests. The Reviews queue shows every open
+// PR of a workspace's repos — PRs opened outside the issue flow have no
+// issues row to sync from, so they must come straight from GitHub. Token
+// priority mirrors fetchPullFiles: App installation token, then the optional
+// GITHUB_TOKEN env, then unauthenticated (public repos only).
+export async function listOpenPulls(
+  repo: string,
+  token?: string | null
+): Promise<OpenPull[]> {
+  const headers = githubApiHeaders(token || process.env.GITHUB_TOKEN)
+  const res = await fetch(
+    `https://api.github.com/repos/${repo}/pulls?state=open&per_page=100`,
+    { headers }
+  )
+  if (!res.ok) {
+    throw new Error(`GitHub returned ${res.status} listing pulls for ${repo}`)
+  }
+  const data = (await res.json()) as Array<{
+    number: number
+    html_url: string
+    title: string
+    draft?: boolean
+    created_at: string
+    head?: { ref?: string }
+    base?: { ref?: string }
+    user?: { login?: string; avatar_url?: string }
+  }>
+  return data.map((pull) => ({
+    number: pull.number,
+    url: pull.html_url,
+    title: pull.title,
+    branch: pull.head?.ref ?? ``,
+    baseBranch: pull.base?.ref ?? ``,
+    draft: Boolean(pull.draft),
+    authorLogin: pull.user?.login ?? null,
+    authorAvatarUrl: pull.user?.avatar_url ?? null,
+    createdAt: pull.created_at,
+  }))
+}
+
 // Fetch a pull request's changed files from GitHub for the diff view.
 //
 // Token priority: a `token` passed in (the App installation token — covers

--- a/apps/web/src/lib/trpc/repositories.ts
+++ b/apps/web/src/lib/trpc/repositories.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 import { TRPCError } from "@trpc/server"
-import { and, asc, eq, isNull } from "drizzle-orm"
+import { and, asc, eq, isNotNull, isNull } from "drizzle-orm"
 import type { db } from "@/db/connection"
 import { router, authedProcedure } from "@/lib/trpc"
 import { issues, projects, repositories } from "@/db/schema"
@@ -17,6 +17,12 @@ import {
   resolveRepoInstallationToken,
   resolveRepoInstallationTokenInfo,
 } from "@/lib/integrations/github-app"
+import {
+  GitHubMergeError,
+  listOpenPulls,
+  mergePullRequest,
+  type OpenPull,
+} from "@/lib/integrations/github-pr"
 import {
   assertCanManageRepos,
   assertRepoInstallationAccess,
@@ -256,6 +262,42 @@ async function loadRepository(repositoryId: string) {
   return repo
 }
 
+// The Reviews queue's "everything else" source: open PRs listed live from
+// GitHub for every workspace repo. Short in-process cache so tab switches and
+// re-mounts don't hammer the GitHub API; busted by mergePull.
+const OPEN_PULLS_TTL_MS = 60_000
+interface CachedOpenPulls {
+  expiresAt: number
+  repos: Array<{ repositoryId: string; fullName: string; pulls: OpenPull[] }>
+}
+const openPullsCache = new Map<string, CachedOpenPulls>()
+
+// Resolve the App installation token for a repo row, honoring the same
+// link-gate as installationToken: a token is only used when the installation
+// serving the repo is still claimed by the repo's workspace. Returns null when
+// no gated token is available (callers may still read public repos
+// unauthenticated / via GITHUB_TOKEN).
+async function resolveGatedRepoToken(repo: {
+  workspaceId: string
+  fullName: string
+  installationId: number | null
+}): Promise<string | null> {
+  if (!githubAppConfigured()) return null
+  const resolved = await resolveRepoInstallationTokenInfo(repo.fullName, {
+    fallbackInstallationId: repo.installationId,
+  })
+  if (!resolved) return null
+  if (
+    !(await isInstallationLinkedToWorkspace(
+      repo.workspaceId,
+      resolved.installationId
+    ))
+  ) {
+    return null
+  }
+  return resolved.token
+}
+
 export const repositoriesRouter = router({
   // Member-readable (moderator-only on public workspaces): the workspace's
   // repos + the projects each one backs (for the settings "in use by" chips
@@ -315,6 +357,144 @@ export const repositoriesRouter = router({
           .filter((p) => p.repositoryId === repo.id)
           .map((p) => ({ id: p.id, name: p.name, slug: p.slug })),
       }))
+    }),
+
+  // Member-readable: every open pull request across the workspace's repos
+  // that is NOT already linked to an issue (those rows render from the synced
+  // issues shape). Listed live from GitHub so PRs opened outside the issue
+  // flow — release PRs on other branches, manual PRs, external contributors —
+  // still land in the Reviews queue.
+  openPulls: authedProcedure
+    .input(z.object({ workspaceId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      await assertRepoCapability(ctx.session.user.id, input.workspaceId)
+
+      const cached = openPullsCache.get(input.workspaceId)
+      if (cached && cached.expiresAt > Date.now()) {
+        return { repos: cached.repos }
+      }
+
+      const repos = await ctx.db
+        .select({
+          id: repositories.id,
+          fullName: repositories.fullName,
+          workspaceId: repositories.workspaceId,
+          installationId: repositories.installationId,
+        })
+        .from(repositories)
+        .where(
+          and(
+            eq(repositories.workspaceId, input.workspaceId),
+            isNull(repositories.archivedAt)
+          )
+        )
+        .orderBy(asc(repositories.sortOrder), asc(repositories.fullName))
+
+      // PRs already linked to an issue are excluded by URL — the issue rows
+      // carry them (regardless of the row's possibly-drifted prState).
+      const linkedRows = await ctx.db
+        .select({ prUrl: issues.prUrl })
+        .from(issues)
+        .innerJoin(projects, eq(projects.id, issues.projectId))
+        .where(
+          and(
+            eq(projects.workspaceId, input.workspaceId),
+            isNotNull(issues.prUrl)
+          )
+        )
+      const linkedUrls = new Set(
+        linkedRows.map((row) => row.prUrl).filter(Boolean)
+      )
+
+      const results = await Promise.all(
+        repos.map(async (repo) => {
+          try {
+            const token = await resolveGatedRepoToken(repo)
+            const pulls = await listOpenPulls(repo.fullName, token)
+            return {
+              repositoryId: repo.id,
+              fullName: repo.fullName,
+              pulls: pulls.filter((pull) => !linkedUrls.has(pull.url)),
+            }
+          } catch {
+            // Unreachable repo (App access revoked, private repo without a
+            // token, GitHub hiccup) — the queue shows what it can.
+            return { repositoryId: repo.id, fullName: repo.fullName, pulls: [] }
+          }
+        })
+      )
+
+      openPullsCache.set(input.workspaceId, {
+        expiresAt: Date.now() + OPEN_PULLS_TTL_MS,
+        repos: results,
+      })
+      return { repos: results }
+    }),
+
+  // Member-gated squash-merge for a pull request WITHOUT an issue link (the
+  // issue-linked path is issues.mergePr, which also syncs the issue row).
+  // Same trust model as installationToken: the workspace's ownership of the
+  // repo row plus the installation link-gate authorizes the merge.
+  mergePull: authedProcedure
+    .input(
+      z.object({
+        repositoryId: z.string().uuid(),
+        prNumber: z.number().int().positive(),
+      })
+    )
+    .mutation(async ({ ctx, input }): Promise<{ merged: true }> => {
+      const repo = await loadRepository(input.repositoryId)
+      await assertRepoCapability(ctx.session.user.id, repo.workspaceId)
+      if (!githubAppConfigured()) {
+        throw new TRPCError({
+          code: `PRECONDITION_FAILED`,
+          message: `GitHub App is not configured on this instance`,
+        })
+      }
+      const token = await resolveGatedRepoToken(repo)
+      if (!token) {
+        throw new TRPCError({
+          code: `PRECONDITION_FAILED`,
+          message: `The GitHub App no longer has access to ${repo.fullName}. Re-grant it on GitHub (workspace settings → Repositories), then retry.`,
+        })
+      }
+
+      try {
+        await mergePullRequest({
+          repo: repo.fullName,
+          prNumber: input.prNumber,
+          token,
+        })
+      } catch (err) {
+        if (err instanceof GitHubMergeError) {
+          if (err.status === 405) {
+            throw new TRPCError({
+              code: `PRECONDITION_FAILED`,
+              message: err.message,
+            })
+          }
+          if (err.status === 409) {
+            throw new TRPCError({
+              code: `CONFLICT`,
+              message: `Head branch changed on GitHub — refresh and try again`,
+            })
+          }
+          if (err.status === 404) {
+            throw new TRPCError({
+              code: `NOT_FOUND`,
+              message: `Pull request not found on GitHub`,
+            })
+          }
+          throw new TRPCError({
+            code: `INTERNAL_SERVER_ERROR`,
+            message: `GitHub merge failed: ${err.message}`,
+          })
+        }
+        throw err
+      }
+
+      openPullsCache.delete(repo.workspaceId)
+      return { merged: true }
     }),
 
   // Owner/admin: register a repo reachable through one of the CALLER's GitHub

--- a/apps/web/src/routes/w/$workspaceSlug/reviews/index.tsx
+++ b/apps/web/src/routes/w/$workspaceSlug/reviews/index.tsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router"
 import { ExternalLink, GitMerge, GitPullRequest, Loader2 } from "lucide-react"
 import type { Issue } from "@/db/schema"
+import type { OpenPull } from "@/lib/integrations/github-pr"
 import { EmptyState } from "@/components/empty-state"
 import { useReviewsData } from "@/hooks/use-reviews-data"
 import { useWorkspaceBySlug } from "@/hooks/use-workspace-data"
@@ -22,7 +23,9 @@ import {
 // Cross-project review queue: every issue in the workspace with an open PR,
 // grouped by project, with a one-click (confirmed) squash-merge that goes
 // through the GitHub App server-side. Deliberately filter-free — the queue
-// should be short.
+// should be short. Open PRs WITHOUT an issue link (release PRs, manual PRs,
+// external contributors) are listed too, grouped by repository, straight from
+// GitHub.
 export const Route = createFileRoute(`/w/$workspaceSlug/reviews/`)({
   beforeLoad: async ({ context }) => {
     if (!context.session) {
@@ -35,17 +38,34 @@ export const Route = createFileRoute(`/w/$workspaceSlug/reviews/`)({
   component: ReviewsPage,
 })
 
+interface ExternalMergeTarget {
+  repositoryId: string
+  fullName: string
+  pull: OpenPull
+}
+
 function ReviewsPage() {
   const { workspaceSlug } = Route.useParams()
   const navigate = useNavigate()
   const workspace = useWorkspaceBySlug(workspaceSlug)
-  const { groups, count, isLoading, userMap } = useReviewsData(workspace)
+  const {
+    groups,
+    externalGroups,
+    count,
+    isLoading,
+    externalLoading,
+    userMap,
+    removeExternalPull,
+  } = useReviewsData(workspace)
 
   // The row whose confirm dialog is open, and the rows with an in-flight
   // merge. A successful merge keeps its spinner until the Electric echo flips
-  // prState and the row leaves the list.
+  // prState and the row leaves the list; external PRs have no echo and are
+  // removed locally on success.
   const [mergeTarget, setMergeTarget] = useState<Issue | null>(null)
   const [mergingIds, setMergingIds] = useState<Set<string>>(new Set())
+  const [externalMergeTarget, setExternalMergeTarget] =
+    useState<ExternalMergeTarget | null>(null)
 
   const openIssue = (projectSlug: string, issueIdentifier: string) => {
     void navigate({
@@ -70,6 +90,35 @@ function ReviewsPage() {
     })
   }
 
+  const externalPullKey = (repositoryId: string, prNumber: number) =>
+    `${repositoryId}#${prNumber}`
+
+  const confirmExternalMerge = () => {
+    const target = externalMergeTarget
+    if (!target) return
+    setExternalMergeTarget(null)
+    const key = externalPullKey(target.repositoryId, target.pull.number)
+    setMergingIds((prev) => new Set(prev).add(key))
+    trpc.repositories.mergePull
+      .mutate({
+        repositoryId: target.repositoryId,
+        prNumber: target.pull.number,
+      })
+      .then(() => {
+        removeExternalPull(target.repositoryId, target.pull.number)
+      })
+      .catch(() => {
+        // Toast already shown — unstick the spinner for a retry.
+      })
+      .finally(() => {
+        setMergingIds((prev) => {
+          const next = new Set(prev)
+          next.delete(key)
+          return next
+        })
+      })
+  }
+
   if (!workspace) {
     return <div className="text-muted-foreground text-sm p-6">Loading…</div>
   }
@@ -92,13 +141,18 @@ function ReviewsPage() {
         {isLoading ? (
           <div className="text-muted-foreground p-6 text-sm">Loading…</div>
         ) : count === 0 ? (
-          <EmptyState
-            icon={GitPullRequest}
-            title="No open pull requests"
-            description="When Claude opens a pull request for an issue, it lands here for review."
-          />
+          externalLoading ? (
+            <div className="text-muted-foreground p-6 text-sm">Loading…</div>
+          ) : (
+            <EmptyState
+              icon={GitPullRequest}
+              title="No open pull requests"
+              description="Open pull requests in this workspace's repositories land here for review."
+            />
+          )
         ) : (
-          groups.map((group) => (
+          <>
+          {groups.map((group) => (
             <div key={group.project.id} className="mb-4">
               <div
                 className="flex items-center gap-1.5 rounded-t-md border-b border-border/50 px-3 py-1.5"
@@ -203,7 +257,105 @@ function ReviewsPage() {
                 )
               })}
             </div>
-          ))
+          ))}
+
+          {externalGroups.map((group) => (
+            <div key={group.repositoryId} className="mb-4">
+              <div
+                className="flex items-center gap-1.5 rounded-t-md border-b border-border/50 px-3 py-1.5"
+                style={{ backgroundColor: `rgba(113, 113, 122, 0.08)` }}
+              >
+                <GitPullRequest className="h-2.5 w-2.5 shrink-0 text-muted-foreground" />
+                <span className="text-sm font-medium">{group.fullName}</span>
+                <span className="text-xs text-muted-foreground">
+                  not linked to an issue · {group.pulls.length}
+                </span>
+              </div>
+
+              {group.pulls.map((pull) => {
+                const key = externalPullKey(group.repositoryId, pull.number)
+                const merging = mergingIds.has(key)
+                return (
+                  <div
+                    key={pull.number}
+                    className="group/row grid h-11 cursor-pointer grid-cols-[1.5rem_4.5rem_1fr_auto] items-center border-b border-border/30 px-3 hover:bg-muted/50"
+                    onClick={() =>
+                      window.open(pull.url, `_blank`, `noopener,noreferrer`)
+                    }
+                    data-testid={`review-pull-${group.fullName}-${pull.number}`}
+                  >
+                    <GitPullRequest className="h-4 w-4 text-emerald-500" />
+                    <span className="truncate font-mono text-xs text-muted-foreground">
+                      #{pull.number}
+                    </span>
+                    <span className="min-w-0 truncate pr-2 text-sm">
+                      {pull.title}
+                    </span>
+                    <div className="flex items-center gap-2">
+                      {pull.draft && <Badge variant="secondary">Draft</Badge>}
+                      {pull.branch && (
+                        <Badge
+                          variant="outline"
+                          className="hidden font-mono text-xs md:inline-flex"
+                        >
+                          {pull.branch}
+                        </Badge>
+                      )}
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7"
+                        aria-label="Open pull request on GitHub"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          window.open(pull.url, `_blank`, `noopener,noreferrer`)
+                        }}
+                      >
+                        <ExternalLink className="h-3.5 w-3.5" />
+                      </Button>
+                      {pull.authorAvatarUrl && (
+                        <Avatar className="size-5">
+                          <AvatarImage
+                            src={pull.authorAvatarUrl}
+                            alt={pull.authorLogin ?? `PR author`}
+                          />
+                          <AvatarFallback className="text-[0.625rem]">
+                            {getInitials(pull.authorLogin ?? `?`)}
+                          </AvatarFallback>
+                        </Avatar>
+                      )}
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={merging || pull.draft}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          setExternalMergeTarget({
+                            repositoryId: group.repositoryId,
+                            fullName: group.fullName,
+                            pull,
+                          })
+                        }}
+                      >
+                        {merging ? (
+                          <>
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                            Merging…
+                          </>
+                        ) : (
+                          <>
+                            <GitMerge className="h-3.5 w-3.5" />
+                            Merge
+                          </>
+                        )}
+                      </Button>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          ))}
+          </>
         )}
       </div>
 
@@ -225,6 +377,28 @@ function ReviewsPage() {
               Cancel
             </Button>
             <Button onClick={confirmMerge}>Merge pull request</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={externalMergeTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setExternalMergeTarget(null)
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{`Merge ${externalMergeTarget?.fullName}#${externalMergeTarget?.pull.number}?`}</DialogTitle>
+            <DialogDescription>
+              {`Squash-merges "${externalMergeTarget?.pull.title}" (${externalMergeTarget?.pull.branch} → ${externalMergeTarget?.pull.baseBranch}) via the GitHub App. This pull request is not linked to an issue.`}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setExternalMergeTarget(null)}>
+              Cancel
+            </Button>
+            <Button onClick={confirmExternalMerge}>Merge pull request</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>


### PR DESCRIPTION
The Reviews section only showed issues with `prState = 'open'` from the synced issues shape, so any PR without an issue link (release PRs on `rev/*` branches, manual PRs, external contributors) never appeared.

- `repositories.openPulls` (tRPC, member-gated): lists open PRs live from GitHub for every non-archived workspace repo — link-gated App installation token with `GITHUB_TOKEN`/unauthenticated fallback for public repos, 60s in-process cache, deduped server-side against issue-linked `prUrl`s so linked PRs keep rendering only from their issue rows.
- `repositories.mergePull` (tRPC, member-gated): the same confirmed squash-merge for unlinked PRs (link-gated token, GitHub error mapping mirroring `issues.mergePr`); busts the openPulls cache.
- Reviews page: per-repo "not linked to an issue" groups below the project groups — PR number, title, draft/branch badges, GitHub author avatar, external link, Merge button (drafts disabled). Row click opens the PR on GitHub. Successful merges remove the row locally (no Electric echo for external PRs). The synced queue renders without waiting on the GitHub fetch.

Verification: typecheck clean; 715/715 unit tests pass; endpoints probed on the dev server (401 unauthenticated); `listOpenPulls("Niach/exponential")` returns exactly the five previously-invisible rev/* PRs (#24–#28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)