### PR TITLE
desktop: reviews tool window lists unlinked open PRs

### DIFF
--- a/apps/desktop/crates/api/src/repositories.rs
+++ b/apps/desktop/crates/api/src/repositories.rs
@@ -62,10 +62,67 @@ impl fmt::Debug for InstallationToken {
     }
 }
 
+/// One repo's open pull requests from `repositories.openPulls`. Every pull is
+/// guaranteed issue-UNLINKED — the server excludes PRs a synced issue row
+/// already carries, so the Reviews queue renders these below the issue rows
+/// without dedup work.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenPullsRepo {
+    pub repository_id: String,
+    /// `owner/name`.
+    pub full_name: String,
+    pub pulls: Vec<OpenPull>,
+}
+
+/// One open pull request as GitHub lists it (no issues row backs these —
+/// release PRs, manual branches, external contributors).
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenPull {
+    pub number: u64,
+    pub url: String,
+    pub title: String,
+    /// Head branch name.
+    pub branch: String,
+    pub base_branch: String,
+    pub draft: bool,
+    #[serde(default)]
+    pub author_login: Option<String>,
+    #[serde(default)]
+    pub author_avatar_url: Option<String>,
+    /// ISO timestamp.
+    pub created_at: String,
+}
+
+/// Output of `repositories.mergePull` — `{"merged": true}` on success.
+#[derive(Clone, Copy, Debug, Deserialize)]
+pub struct MergePullResult {
+    pub merged: bool,
+}
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ForIssueInput<'a> {
     issue_id: &'a str,
+}
+
+#[derive(Deserialize)]
+struct OpenPullsOutput {
+    repos: Vec<OpenPullsRepo>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct OpenPullsInput<'a> {
+    workspace_id: &'a str,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MergePullInput<'a> {
+    repository_id: &'a str,
+    pr_number: u64,
 }
 
 #[derive(Serialize)]
@@ -91,6 +148,34 @@ pub fn installation_token(
     trpc.mutation(
         "repositories.installationToken",
         &InstallationTokenInput { repository_id },
+    )
+}
+
+/// `repositories.openPulls` — query. Member-gated, server-cached (~60s), so
+/// callers refetch on view-open/workspace-switch and never poll.
+pub fn open_pulls(
+    trpc: &TrpcClient,
+    workspace_id: &str,
+) -> Result<Vec<OpenPullsRepo>, ApiError> {
+    let out: OpenPullsOutput =
+        trpc.query_with_input("repositories.openPulls", &OpenPullsInput { workspace_id })?;
+    Ok(out.repos)
+}
+
+/// `repositories.mergePull` — mutation (GitHub-App squash merge of an
+/// issue-unlinked PR; the issue-linked path is `issues.mergePr`). There is no
+/// Electric echo — the caller drops the row from its local state on success.
+pub fn merge_pull(
+    trpc: &TrpcClient,
+    repository_id: &str,
+    pr_number: u64,
+) -> Result<MergePullResult, ApiError> {
+    trpc.mutation(
+        "repositories.mergePull",
+        &MergePullInput {
+            repository_id,
+            pr_number,
+        },
     )
 }
 
@@ -167,6 +252,64 @@ mod tests {
         assert!(!debug.contains("ghs_secret123"), "token leaked: {debug}");
         assert!(debug.contains("***"));
         assert!(debug.contains("acme/web"));
+    }
+
+    #[test]
+    fn open_pulls_decodes_repo_groups() {
+        let (base, captured) = one_shot_server(
+            200,
+            r#"{"result":{"data":{"repos":[{"repositoryId":"repo-1","fullName":"acme/web","pulls":[{"number":42,"url":"https://github.com/acme/web/pull/42","title":"Fix login","branch":"fix/login","baseBranch":"main","draft":true,"authorLogin":"octocat","authorAvatarUrl":null,"createdAt":"2026-07-10T08:00:00Z"}]},{"repositoryId":"repo-2","fullName":"acme/api","pulls":[]}]}}}"#,
+        );
+        let repos = open_pulls(&client(&base), "11111111-2222-3333-4444-555555555555").unwrap();
+        assert_eq!(repos.len(), 2);
+        assert_eq!(
+            repos[0],
+            OpenPullsRepo {
+                repository_id: "repo-1".to_string(),
+                full_name: "acme/web".to_string(),
+                pulls: vec![OpenPull {
+                    number: 42,
+                    url: "https://github.com/acme/web/pull/42".to_string(),
+                    title: "Fix login".to_string(),
+                    branch: "fix/login".to_string(),
+                    base_branch: "main".to_string(),
+                    draft: true,
+                    author_login: Some("octocat".to_string()),
+                    author_avatar_url: None,
+                    created_at: "2026-07-10T08:00:00Z".to_string(),
+                }],
+            }
+        );
+        assert!(repos[1].pulls.is_empty());
+        let request = captured.recv_timeout(Duration::from_secs(5)).unwrap();
+        // Query → GET with percent-encoded raw-JSON input ({"workspaceId":…}).
+        assert!(request.starts_with("GET /api/trpc/repositories.openPulls?input=%7B%22workspaceId%22%3A%2211111111-2222-3333-4444-555555555555%22%7D HTTP/1.1"));
+    }
+
+    #[test]
+    fn merge_pull_posts_camel_case_input_and_decodes_result() {
+        let (base, captured) = one_shot_server(200, r#"{"result":{"data":{"merged":true}}}"#);
+        let out = merge_pull(&client(&base), "repo-1", 42).unwrap();
+        assert!(out.merged);
+        let request = captured.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert!(request.starts_with("POST /api/trpc/repositories.mergePull HTTP/1.1"));
+        assert!(request.ends_with(r#"{"repositoryId":"repo-1","prNumber":42}"#));
+    }
+
+    #[test]
+    fn merge_pull_surfaces_the_server_message() {
+        // e.g. a 405 "not mergeable" mapped to PRECONDITION_FAILED server-side.
+        let (base, _captured) = one_shot_server(
+            412,
+            r#"{"error":{"message":"Pull request is not mergeable","code":-32012,"data":{"code":"PRECONDITION_FAILED","httpStatus":412}}}"#,
+        );
+        match merge_pull(&client(&base), "repo-1", 42) {
+            Err(ApiError::Http { status, message }) => {
+                assert_eq!(status, 412);
+                assert!(message.contains("not mergeable"));
+            }
+            other => panic!("expected 412 Http error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/apps/desktop/crates/ui/src/queries.rs
+++ b/apps/desktop/crates/ui/src/queries.rs
@@ -389,6 +389,33 @@ pub fn review_groups(cx: &App, workspace_id: &str) -> Vec<ReviewGroup> {
     groups
 }
 
+/// The Reviews tool window's unlinked-PR sections: keep only repos that have
+/// open pulls (the server returns every workspace repo, unreachable ones with
+/// an empty list — an empty section is noise, web parity).
+pub fn visible_pull_repos(
+    repos: &[api::repositories::OpenPullsRepo],
+) -> Vec<api::repositories::OpenPullsRepo> {
+    repos
+        .iter()
+        .filter(|repo| !repo.pulls.is_empty())
+        .cloned()
+        .collect()
+}
+
+/// Drop a pull from the fetched `repositories.openPulls` state after a
+/// successful merge — the mutation has no Electric echo, so removal is local.
+pub fn remove_merged_pull(
+    repos: &mut [api::repositories::OpenPullsRepo],
+    repository_id: &str,
+    number: u64,
+) {
+    for repo in repos.iter_mut() {
+        if repo.repository_id == repository_id {
+            repo.pulls.retain(|pull| pull.number != number);
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Releases (EXP-56 — the Releases tool window + issue release picker)
 // ---------------------------------------------------------------------------
@@ -565,6 +592,57 @@ mod tests {
             "priority": "none",
         }))
         .unwrap()
+    }
+
+    fn pull(number: u64) -> api::repositories::OpenPull {
+        serde_json::from_value(json!({
+            "number": number,
+            "url": format!("https://github.com/acme/web/pull/{number}"),
+            "title": "t",
+            "branch": "b",
+            "baseBranch": "main",
+            "draft": false,
+            "createdAt": "2026-07-10T08:00:00Z",
+        }))
+        .unwrap()
+    }
+
+    fn pull_repo(repository_id: &str, numbers: &[u64]) -> api::repositories::OpenPullsRepo {
+        serde_json::from_value(json!({
+            "repositoryId": repository_id,
+            "fullName": format!("acme/{repository_id}"),
+            "pulls": [],
+        }))
+        .map(|mut repo: api::repositories::OpenPullsRepo| {
+            repo.pulls = numbers.iter().map(|n| pull(*n)).collect();
+            repo
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn visible_pull_repos_hides_empty_repos() {
+        let repos = vec![pull_repo("repo-1", &[1, 2]), pull_repo("repo-2", &[])];
+        let visible = visible_pull_repos(&repos);
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].repository_id, "repo-1");
+    }
+
+    #[test]
+    fn remove_merged_pull_drops_only_the_matching_row() {
+        let mut repos = vec![pull_repo("repo-1", &[1, 2]), pull_repo("repo-2", &[1])];
+        remove_merged_pull(&mut repos, "repo-1", 1);
+        assert_eq!(
+            repos[0].pulls.iter().map(|p| p.number).collect::<Vec<_>>(),
+            [2]
+        );
+        // Same PR number in another repo is untouched.
+        assert_eq!(repos[1].pulls.len(), 1);
+        // Unknown targets are a no-op.
+        remove_merged_pull(&mut repos, "repo-9", 1);
+        remove_merged_pull(&mut repos, "repo-1", 99);
+        assert_eq!(repos[0].pulls.len(), 1);
+        assert_eq!(repos[1].pulls.len(), 1);
     }
 
     #[test]

--- a/apps/desktop/crates/ui/src/sidebar.rs
+++ b/apps/desktop/crates/ui/src/sidebar.rs
@@ -75,8 +75,10 @@ pub(crate) enum ToolWindow {
     MyIssues,
     /// Every issue in the workspace (mini list).
     AllIssues,
-    /// Open pull requests across the workspace, grouped by project, with an
-    /// inline squash-merge action (server-side via the GitHub App).
+    /// Open pull requests across the workspace: issue-linked ones grouped by
+    /// project, plus GitHub-listed PRs not linked to any issue grouped by
+    /// repo — both with an inline squash-merge action (server-side via the
+    /// GitHub App).
     Reviews,
     /// The workspace's releases (EXP-56): list + in-panel detail (issues
     /// grouped by status; rows open the issue detail in the center pane).
@@ -559,22 +561,42 @@ pub struct SidebarPanel {
     /// Scroll position of the flow graph's lane list (EXP-67: the full
     /// uncapped list scrolls instead of collapsing behind "+N more").
     flow_scroll: ScrollHandle,
-    /// Two-click merge confirm: the armed row's issue id. Any other click or
-    /// ~5s of inactivity disarms.
+    /// Two-click merge confirm: the armed row's key — an issue id, or
+    /// `repo#number` for an unlinked pull (see [`pull_merge_key`]). Any other
+    /// click or ~5s of inactivity disarms.
     review_arm: Option<String>,
     /// Bumped on every arm/disarm — a stale disarm timer checks it before
     /// clearing so it never cancels a newer arm.
     review_arm_seq: u64,
-    /// Issue ids with an in-flight `issues.mergePr` call. On success the id
-    /// stays until the Electric echo removes the row (render prunes it).
+    /// Row keys with an in-flight merge call (`issues.mergePr` or
+    /// `repositories.mergePull`). Issue rows keep the id until the Electric
+    /// echo removes the row (render prunes it); pull rows clear on completion.
     review_merging: HashSet<String>,
-    /// The last merge failure, `(issue_id, message)` — a caption under the
+    /// The last merge failure, `(row_key, message)` — a caption under the
     /// row, cleared on the next attempt.
     review_error: Option<(String, String)>,
+    /// Fetched `repositories.openPulls` result: `(workspace_id, repos)` —
+    /// open PRs with NO issue link (release PRs, manual branches, external
+    /// contributors), listed straight from GitHub. Rendered below the project
+    /// groups; a merged pull is removed locally (no Electric echo).
+    open_pulls: Option<(String, Vec<api::repositories::OpenPullsRepo>)>,
+    /// The workspace the current openPulls fetch belongs to. Cleared whenever
+    /// the Reviews tool window is inactive, so re-opening refetches (the
+    /// server caches ~60s; there is deliberately no polling).
+    open_pulls_key: Option<String>,
+    /// Bumped per fetch — a stale response checks it before landing.
+    open_pulls_seq: u64,
     /// The release detail's status-grouped issue list (the shared board core,
     /// pinned to `IssueQuery::Release`).
     release_list: Entity<IssueListView>,
     _subscriptions: Vec<Subscription>,
+}
+
+/// Merge-state key for an unlinked pull. `review_arm`/`review_merging`/
+/// `review_error` share the namespace with issue rows, whose keys are issue
+/// UUIDs — `repo-uuid#number` can never collide with those.
+fn pull_merge_key(repository_id: &str, number: u64) -> String {
+    format!("{repository_id}#{number}")
 }
 
 /// Latest-notification kind → the inbox row's leading type-badge glyph (the
@@ -638,6 +660,9 @@ impl SidebarPanel {
             review_arm_seq: 0,
             review_merging: HashSet::new(),
             review_error: None,
+            open_pulls: None,
+            open_pulls_key: None,
+            open_pulls_seq: 0,
             release_list,
             flow,
             flow_scroll: ScrollHandle::new(),
@@ -952,28 +977,48 @@ impl SidebarPanel {
 
     // -- Reviews tool window ----------------------------------------------------
 
-    /// *Reviews* tool window: open pull requests across the workspace,
-    /// grouped by project, each row with a two-click inline merge confirm.
-    /// Merging goes through the server (`issues.mergePr`, GitHub App squash)
-    /// — never local git; on success the Electric echo flips `pr_state` and
-    /// the row leaves the list.
+    /// *Reviews* tool window: open pull requests across the workspace, each
+    /// row with a two-click inline merge confirm. Issue-linked PRs come from
+    /// the synced issues shape, grouped by project; below them, PRs NOT
+    /// linked to any issue (release PRs, manual branches, external
+    /// contributors) come from a background `repositories.openPulls` fetch,
+    /// grouped by repo — the synced list never waits on GitHub. Merging goes
+    /// through the server (`issues.mergePr` / `repositories.mergePull`,
+    /// GitHub App squash) — never local git; issue rows leave the list via
+    /// the Electric echo, unlinked pulls are removed locally.
     fn render_reviews_tool(&mut self, cx: &mut gpui::Context<Self>) -> gpui::AnyElement {
         let collections = Store::global(cx).collections().clone();
         let is_ready = collections.issues.read(cx).is_ready()
             && collections.projects.read(cx).is_ready();
-        let groups = active_workspace_id(&self.nav, cx)
-            .map(|id| queries::review_groups(cx, &id))
+        let workspace_id = active_workspace_id(&self.nav, cx);
+        if let Some(id) = workspace_id.as_deref() {
+            self.ensure_open_pulls(id, cx);
+        }
+        let groups = workspace_id
+            .as_deref()
+            .map(|id| queries::review_groups(cx, id))
+            .unwrap_or_default();
+        let pull_repos: Vec<api::repositories::OpenPullsRepo> = self
+            .open_pulls
+            .as_ref()
+            .filter(|(ws, _)| Some(ws.as_str()) == workspace_id.as_deref())
+            .map(|(_, repos)| queries::visible_pull_repos(repos))
             .unwrap_or_default();
 
         // Rows that merged/closed (or left the workspace scope) drop their
         // transient merge state — this is also where a successful merge's
         // lingering "Merging…" id gets collected once the echo lands.
         {
-            let live_ids: HashSet<&str> = groups
+            let mut live_ids: HashSet<String> = groups
                 .iter()
-                .flat_map(|group| group.issues.iter().map(|issue| issue.id.as_str()))
+                .flat_map(|group| group.issues.iter().map(|issue| issue.id.clone()))
                 .collect();
-            self.review_merging.retain(|id| live_ids.contains(id.as_str()));
+            for repo in &pull_repos {
+                for pull in &repo.pulls {
+                    live_ids.insert(pull_merge_key(&repo.repository_id, pull.number));
+                }
+            }
+            self.review_merging.retain(|id| live_ids.contains(id));
             if self
                 .review_arm
                 .as_deref()
@@ -994,7 +1039,7 @@ impl SidebarPanel {
 
         let body: gpui::AnyElement = if !is_ready {
             self.list_skeleton(cx)
-        } else if groups.is_empty() {
+        } else if groups.is_empty() && pull_repos.is_empty() {
             self.list_note("No open pull requests.", cx)
         } else {
             let muted = cx.theme().muted_foreground;
@@ -1025,6 +1070,45 @@ impl SidebarPanel {
                 );
                 for issue in &group.issues {
                     children.push(self.review_row(issue, cx));
+                }
+            }
+            for repo in &pull_repos {
+                children.push(
+                    h_flex()
+                        .px_2()
+                        .pt_2()
+                        .pb_0p5()
+                        .gap_1p5()
+                        .items_center()
+                        .child(
+                            Icon::from(ExpIcon::GitPullRequest)
+                                .xsmall()
+                                .flex_shrink_0()
+                                .text_color(muted),
+                        )
+                        .child(
+                            div()
+                                .min_w_0()
+                                .text_xs()
+                                .truncate()
+                                .font_weight(FontWeight::SEMIBOLD)
+                                .text_color(muted)
+                                .child(SharedString::from(repo.full_name.clone())),
+                        )
+                        .child(
+                            div()
+                                .flex_shrink_0()
+                                .text_xs()
+                                .text_color(muted.opacity(0.8))
+                                .child(SharedString::from(format!(
+                                    "not linked to an issue \u{00B7} {}",
+                                    repo.pulls.len()
+                                ))),
+                        )
+                        .into_any_element(),
+                );
+                for pull in &repo.pulls {
+                    children.push(self.pull_row(&repo.repository_id, pull, cx));
                 }
             }
             div()
@@ -1180,22 +1264,7 @@ impl SidebarPanel {
             return;
         }
         if self.review_arm.as_deref() != Some(issue_id.as_str()) {
-            self.review_arm = Some(issue_id);
-            self.review_arm_seq += 1;
-            let seq = self.review_arm_seq;
-            cx.spawn(async move |this, cx| {
-                cx.background_executor()
-                    .timer(std::time::Duration::from_secs(5))
-                    .await;
-                let _ = this.update(cx, |this, cx| {
-                    if this.review_arm_seq == seq && this.review_arm.is_some() {
-                        this.review_arm = None;
-                        cx.notify();
-                    }
-                });
-            })
-            .detach();
-            cx.notify();
+            self.arm_merge_confirm(issue_id, cx);
             return;
         }
 
@@ -1231,6 +1300,270 @@ impl SidebarPanel {
                 }
                 // Success: nothing to do — the collection observer re-renders
                 // when the echo flips `pr_state` and the row leaves the list.
+            });
+        })
+        .detach();
+    }
+
+    /// First click of the two-click merge confirm: arm `key` (an issue id or
+    /// an unlinked-pull key) and start the ~5s auto-disarm timer.
+    fn arm_merge_confirm(&mut self, key: String, cx: &mut gpui::Context<Self>) {
+        self.review_arm = Some(key);
+        self.review_arm_seq += 1;
+        let seq = self.review_arm_seq;
+        cx.spawn(async move |this, cx| {
+            cx.background_executor()
+                .timer(std::time::Duration::from_secs(5))
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                if this.review_arm_seq == seq && this.review_arm.is_some() {
+                    this.review_arm = None;
+                    cx.notify();
+                }
+            });
+        })
+        .detach();
+        cx.notify();
+    }
+
+    /// Kick the `repositories.openPulls` fetch when the Reviews tool window
+    /// is shown or the workspace changes — never on a timer (the server
+    /// caches ~60s). Data from another workspace is dropped immediately; a
+    /// reopen in the same workspace keeps rendering the previous result while
+    /// the refresh is in flight.
+    fn ensure_open_pulls(&mut self, workspace_id: &str, cx: &mut gpui::Context<Self>) {
+        if self.open_pulls_key.as_deref() == Some(workspace_id) {
+            return;
+        }
+        self.open_pulls_key = Some(workspace_id.to_string());
+        if self
+            .open_pulls
+            .as_ref()
+            .is_some_and(|(ws, _)| ws != workspace_id)
+        {
+            self.open_pulls = None;
+        }
+        self.open_pulls_seq += 1;
+        let seq = self.open_pulls_seq;
+        let Some(trpc) = queries::trpc_client(cx) else {
+            return;
+        };
+        let ws = workspace_id.to_string();
+        cx.spawn(async move |this, cx| {
+            let call_ws = ws.clone();
+            let result = cx
+                .background_executor()
+                .spawn(async move { api::repositories::open_pulls(&trpc, &call_ws) })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                if this.open_pulls_seq != seq {
+                    return;
+                }
+                match result {
+                    Ok(repos) => {
+                        this.open_pulls = Some((ws, repos));
+                        cx.notify();
+                    }
+                    Err(err) => {
+                        // The synced rows still render; the unlinked section
+                        // just stays absent (same degradation as the web).
+                        log::warn!("[ui] repositories.openPulls failed: {err}");
+                    }
+                }
+            });
+        })
+        .detach();
+    }
+
+    /// One unlinked-PR row: `#N` + title with a trailing Merge button
+    /// (disabled for drafts — GitHub refuses those), sub-line
+    /// `branch → base`, optional Draft pill and error caption. Clicking the
+    /// row opens the PR on GitHub — no local detail exists behind these.
+    fn pull_row(
+        &self,
+        repository_id: &str,
+        pull: &api::repositories::OpenPull,
+        cx: &mut gpui::Context<Self>,
+    ) -> gpui::AnyElement {
+        let theme = cx.theme();
+        let radius = theme.radius;
+        let fg = theme.foreground;
+        let muted = theme.muted_foreground;
+        let accent = theme.accent;
+        let danger = theme.danger;
+        let pr_green = theme::tokens::GREEN.to_hsla();
+
+        let key = pull_merge_key(repository_id, pull.number);
+        let merging = self.review_merging.contains(&key);
+        let armed = self.review_arm.as_deref() == Some(key.as_str());
+        let error: Option<String> = self
+            .review_error
+            .as_ref()
+            .filter(|(id, _)| *id == key)
+            .map(|(_, message)| message.clone());
+
+        let sub = format!("{} \u{2192} {}", pull.branch, pull.base_branch);
+
+        let merge_button = {
+            let mut button = Button::new(SharedString::from(format!("pull-merge-{key}")))
+                .xsmall()
+                .outline();
+            if merging {
+                button = button.label("Merging…").loading(true).disabled(true);
+            } else if pull.draft {
+                button = button.label("Merge").disabled(true);
+            } else if armed {
+                button = button.label("Confirm merge").danger();
+            } else {
+                button = button.label("Merge");
+            }
+            let click_repo = repository_id.to_string();
+            let number = pull.number;
+            button.on_click(cx.listener(move |this, _: &ClickEvent, _, cx| {
+                cx.stop_propagation();
+                this.on_pull_merge_click(click_repo.clone(), number, cx);
+            }))
+        };
+
+        let url = pull.url.clone();
+        v_flex()
+            .id(SharedString::from(format!("pull-{key}")))
+            .w_full()
+            .px_2()
+            .py_1()
+            .gap_0p5()
+            .rounded(radius)
+            .hover(|this| this.bg(accent.opacity(0.3)))
+            .cursor_pointer()
+            .on_click(cx.listener(move |this, _, _, cx| {
+                // Any click outside the armed button disarms the confirm.
+                if this.review_arm.is_some() {
+                    this.review_arm = None;
+                    this.review_arm_seq += 1;
+                    cx.notify();
+                }
+                crate::settings::open_url(cx, url.clone());
+            }))
+            .child(
+                h_flex()
+                    .w_full()
+                    .items_center()
+                    .gap_1p5()
+                    .child(
+                        Icon::from(ExpIcon::GitPullRequest)
+                            .xsmall()
+                            .flex_shrink_0()
+                            .text_color(pr_green),
+                    )
+                    .child(
+                        div()
+                            .flex_shrink_0()
+                            .text_xs()
+                            .text_color(muted)
+                            .font_family(theme::terminal::FONT_FAMILY)
+                            .child(SharedString::from(format!("#{}", pull.number))),
+                    )
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .text_xs()
+                            .truncate()
+                            .text_color(fg)
+                            .child(SharedString::from(pull.title.clone())),
+                    )
+                    .when(pull.draft, |this| {
+                        this.child(
+                            div()
+                                .flex_shrink_0()
+                                .px_1()
+                                .rounded(radius)
+                                .bg(muted.opacity(0.15))
+                                .text_xs()
+                                .text_color(muted)
+                                .child("Draft"),
+                        )
+                    })
+                    .child(merge_button),
+            )
+            .child(
+                div()
+                    .pl_5()
+                    .text_xs()
+                    .truncate()
+                    .text_color(muted)
+                    .child(SharedString::from(sub)),
+            )
+            .when_some(error, |this, message| {
+                this.child(
+                    div()
+                        .pl_5()
+                        .text_xs()
+                        .truncate()
+                        .text_color(danger)
+                        .child(SharedString::from(message)),
+                )
+            })
+            .into_any_element()
+    }
+
+    /// The unlinked-pull Merge flow: same two-click confirm as issue rows,
+    /// firing `repositories.mergePull`. There is no Electric echo — success
+    /// removes the pull from the fetched state; failures caption the row.
+    fn on_pull_merge_click(
+        &mut self,
+        repository_id: String,
+        number: u64,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        let key = pull_merge_key(&repository_id, number);
+        if self.review_merging.contains(&key) {
+            return;
+        }
+        if self.review_arm.as_deref() != Some(key.as_str()) {
+            self.arm_merge_confirm(key, cx);
+            return;
+        }
+
+        // Confirmed — fire the server-side squash merge.
+        self.review_arm = None;
+        self.review_arm_seq += 1;
+        self.review_error = None;
+        let Some(trpc) = queries::trpc_client(cx) else {
+            log::warn!("[ui] repositories.mergePull skipped: no active account");
+            cx.notify();
+            return;
+        };
+        self.review_merging.insert(key.clone());
+        cx.notify();
+        cx.spawn(async move |this, cx| {
+            let call_repo = repository_id.clone();
+            let result = cx
+                .background_executor()
+                .spawn(async move { api::repositories::merge_pull(&trpc, &call_repo, number) })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                this.review_merging.remove(&key);
+                match result {
+                    Ok(_) => {
+                        if let Some((_, repos)) = this.open_pulls.as_mut() {
+                            queries::remove_merged_pull(repos, &repository_id, number);
+                        }
+                    }
+                    Err(err) => {
+                        log::warn!(
+                            "[ui] repositories.mergePull({repository_id}#{number}) failed: {err}"
+                        );
+                        // Show the server's user-facing message when there is
+                        // one; transport-level errors keep the full rendering.
+                        let message = match err {
+                            api::ApiError::Http { message, .. } => message,
+                            other => other.to_string(),
+                        };
+                        this.review_error = Some((key.clone(), message));
+                    }
+                }
+                cx.notify();
             });
         })
         .detach();
@@ -1946,6 +2279,11 @@ fn spawn_release_delete(
 impl Render for SidebarPanel {
     fn render(&mut self, _window: &mut Window, cx: &mut gpui::Context<Self>) -> impl IntoElement {
         let tool = self.shared.read(cx).tool;
+        // Leaving the Reviews tool drops the openPulls fetch key so the next
+        // open refetches (the server cache keeps that cheap).
+        if tool != ToolWindow::Reviews {
+            self.open_pulls_key = None;
+        }
         v_flex()
             .size_full()
             .min_w_0()


### PR DESCRIPTION
Desktop parity for the web Reviews change (#29): the Reviews tool window now also lists open pull requests that are NOT linked to any issue, fetched via the member-gated `repositories.openPulls` tRPC endpoint (server-side 60s cache, already deduped against issue-linked PRs).

- `crates/api/repositories.rs`: serde bindings + `open_pulls` / `merge_pull` calls following the existing `for_issue`/`installationToken` idiom (+3 wire-format tests against the one-shot server harness)
- `crates/ui/queries.rs`: pure `visible_pull_repos` / `remove_merged_pull` helpers (+2 tests)
- `crates/ui/sidebar.rs`: per-repo "not linked to an issue" sections below the project groups — `#number`, title, `branch → base`, Draft pill, row click opens the PR in the browser, and the same armed two-click confirmed merge the issue rows use (`repositories.mergePull`; drafts disabled; success removes the row locally since there is no Electric echo). Fetch runs in the background when the Reviews tool opens and refetches on reopen/workspace switch — no polling, and the synced list never waits on GitHub.

Deliberately unchanged: the rail badge stays issue-linked-only (including the fetched count would need new plumbing into the RailView entity or polling).

Verification: `cargo check` clean; `cargo test -p api -p ui` 309 tests pass (incl. 5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)