### PR TITLE
EXP-110: map replyTo to SES ReplyToAddresses instead of a custom header

### DIFF
--- a/apps/web/src/lib/email.test.ts
+++ b/apps/web/src/lib/email.test.ts
@@ -23,6 +23,7 @@ vi.mock(`@aws-sdk/client-sesv2`, () => {
 type SesInput = {
   FromEmailAddress: string
   Destination: { ToAddresses: string[] }
+  ReplyToAddresses?: string[]
   Content: {
     Simple: {
       Subject: { Data: string }
@@ -116,6 +117,26 @@ describe(`sendEmail with no transport`, () => {
     ).resolves.toMatchObject({ delivered: false })
 
     stderrSpy.mockRestore()
+  })
+})
+
+describe(`sendEmail over the SES transport (mocked)`, () => {
+  it(`maps replyTo to top-level ReplyToAddresses, never a custom header (SES rejects Reply-To there)`, async () => {
+    const email = await importEmail({ AWS_SES_REGION: `eu-central-1` })
+
+    await email.sendEmail({
+      to: `dennis@example.com`,
+      subject: `Contact form`,
+      html: `<p>hi</p>`,
+      text: `hi`,
+      replyTo: `visitor@example.com`,
+    })
+
+    const input = sesCallInput()
+    expect(input.ReplyToAddresses).toEqual([`visitor@example.com`])
+    expect(input.Content.Simple.Headers ?? []).not.toContainEqual(
+      expect.objectContaining({ Name: `Reply-To` })
+    )
   })
 })
 

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -73,6 +73,9 @@ export async function sendEmail(args: {
   subject: string
   html: string
   text: string
+  // SES rejects Reply-To (and other envelope fields) as a custom Simple
+  // header — reply-to must go through this dedicated field, never `headers`.
+  replyTo?: string
   headers?: Record<string, string>
 }): Promise<EmailSendResult> {
   if (process.env.AWS_SES_REGION) {
@@ -82,6 +85,7 @@ export async function sendEmail(args: {
       new SendEmailCommand({
         FromEmailAddress: fromAddress(),
         Destination: { ToAddresses: [args.to] },
+        ReplyToAddresses: args.replyTo ? [args.replyTo] : undefined,
         Content: {
           Simple: {
             Subject: { Data: args.subject, Charset: `UTF-8` },
@@ -114,6 +118,7 @@ export async function sendEmail(args: {
       subject: args.subject,
       html: args.html,
       text: args.text,
+      replyTo: args.replyTo,
       headers: args.headers,
     })
     return {

--- a/apps/web/src/routes/api/contact.ts
+++ b/apps/web/src/routes/api/contact.ts
@@ -169,7 +169,7 @@ async function handleContact(request: Request): Promise<Response> {
       subject,
       html,
       text,
-      headers: { "Reply-To": email },
+      replyTo: email,
     })
     if (!result.delivered) {
       // No transport configured — tell the form so it can fall back to mailto.


### PR DESCRIPTION
Pre-deploy review of EXP-108 found that `/api/contact` smuggles `Reply-To` through custom headers, which the new SES transport maps into `Content.Simple.Headers` — SESv2 rejects `Reply-To` there (400), so every contact-form submission would fail once `AWS_SES_REGION` is set.

- `sendEmail` gains a dedicated `replyTo` arg → top-level `ReplyToAddresses` (SES) / `replyTo` (nodemailer SMTP)
- `/api/contact` uses it instead of the header
- Regression test: replyTo maps to ReplyToAddresses and never lands in Simple.Headers

Fixes EXP-110. Deploy-blocker for the 2026-07-15 release wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)