### PR TITLE
EXP-111: drop release FK constraints before DROP TABLE releases CASCADE

### DIFF
--- a/apps/web/src/db/out/0023_faithful_stark_industries.sql
+++ b/apps/web/src/db/out/0023_faithful_stark_industries.sql
@@ -1,12 +1,15 @@
 -- Historical release timeline events must go BEFORE the enum recreation below
 -- (the USING cast would fail on rows holding the removed values).
 DELETE FROM "issue_events" WHERE "type" IN ('release_added', 'release_removed');--> statement-breakpoint
-ALTER TABLE "releases" DISABLE ROW LEVEL SECURITY;--> statement-breakpoint
-DROP TABLE "releases" CASCADE;--> statement-breakpoint
+-- Referencing FK constraints must be dropped BEFORE the table: DROP TABLE
+-- CASCADE removes them, and the bare DROP CONSTRAINT that drizzle-kit
+-- generated after it would then error and roll back the whole migration.
 ALTER TABLE "coding_sessions" DROP CONSTRAINT "coding_sessions_release_id_releases_id_fk";
 --> statement-breakpoint
 ALTER TABLE "issues" DROP CONSTRAINT "issues_release_id_releases_id_fk";
 --> statement-breakpoint
+ALTER TABLE "releases" DISABLE ROW LEVEL SECURITY;--> statement-breakpoint
+DROP TABLE "releases" CASCADE;--> statement-breakpoint
 ALTER TABLE "issue_events" ALTER COLUMN "type" SET DATA TYPE text;--> statement-breakpoint
 DROP TYPE "public"."issue_event_type";--> statement-breakpoint
 CREATE TYPE "public"."issue_event_type" AS ENUM('status_changed', 'assignee_changed', 'label_added', 'label_removed', 'pr_opened', 'pr_merged', 'project_moved');--> statement-breakpoint


### PR DESCRIPTION
Pre-deploy review of EXP-106 found migration 0023 fails unconditionally: `DROP TABLE "releases" CASCADE` cascades away both referencing FK constraints, then the bare `DROP CONSTRAINT` statements error and roll back the whole migration — even on an empty DB. Every deploy of the current image would fail at the container's migrate step (old container keeps serving; data safe but rollout is bricked).

Fix: reorder — drop the two constraints before the table. Verified: full 0000→0023 chain applies cleanly on a fresh Postgres 17; the review agent additionally verified correct end state with seeded prod-like release data. 0023 has never been applied to any environment, so the in-place edit is safe.

Fixes EXP-111. Deploy-blocker for the 2026-07-15 release wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)