### PR TITLE
EXP-565: desktop 0.14.17: fix the double-lease abort on issue open

### DIFF
--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -225,7 +225,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "api"
-version = "0.14.16"
+version = "0.14.17"
 dependencies = [
  "dirs",
  "domain",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "app"
-version = "0.14.16"
+version = "0.14.17"
 dependencies = [
  "anyhow",
  "api",
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "coding"
-version = "0.14.16"
+version = "0.14.17"
 dependencies = [
  "anyhow",
  "api",
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "domain"
-version = "0.14.16"
+version = "0.14.17"
 dependencies = [
  "serde",
  "serde_json",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "exp-cli"
-version = "0.14.16"
+version = "0.14.17"
 dependencies = [
  "anyhow",
  "api",
@@ -6614,7 +6614,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "steer"
-version = "0.14.16"
+version = "0.14.17"
 dependencies = [
  "api",
  "flume 0.11.1",
@@ -6843,7 +6843,7 @@ dependencies = [
 
 [[package]]
 name = "sync"
-version = "0.14.16"
+version = "0.14.17"
 dependencies = [
  "api",
  "domain",
@@ -6990,7 +6990,7 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "0.14.16"
+version = "0.14.17"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -7005,7 +7005,7 @@ dependencies = [
 
 [[package]]
 name = "theme"
-version = "0.14.16"
+version = "0.14.17"
 dependencies = [
  "gpui",
  "gpui-component",
@@ -7832,7 +7832,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.14.16"
+version = "0.14.17"
 dependencies = [
  "anyhow",
  "api",
@@ -7968,7 +7968,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "updater"
-version = "0.14.16"
+version = "0.14.17"
 dependencies = [
  "anyhow",
  "dirs",

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.14.16"
+version = "0.14.17"
 # The whole repo is Apache-2.0 (EXP-352; verbatim text in the repo-root LICENSE).
 # Every crate inherits this via `license.workspace = true`, except the vendored
 # gpui-markdown-editor which pins its own explicit Apache-2.0.

--- a/apps/desktop/crates/ui/src/comments.rs
+++ b/apps/desktop/crates/ui/src/comments.rs
@@ -26,7 +26,7 @@ use domain::rows::{Comment, User};
 use crate::comment_attachments::{
     attach_button, comment_attachments_strip, pending_attachments_strip, MAX_COMMENT_ATTACHMENTS,
 };
-use crate::emoji_picker::emoji_picker_popover;
+use crate::emoji_picker::{emoji_picker_popover, EmojiPicker};
 use crate::controls::WebControl as _;
 use crate::description_editor::open_issue_by_identifier;
 use crate::icons::{registry, ExpIcon};
@@ -146,6 +146,10 @@ pub(crate) struct CommentRowProps<'a> {
     pub team_id: Option<&'a str>,
     /// Shared attachment-image cache (auth-gated fetch).
     pub images: &'a Entity<ImageCache>,
+    /// EXP-551: the timeline's shared picker + whether the EDIT composer's
+    /// popover is open. Passed in from `&self` — see [`emoji_button`].
+    pub emoji_picker: &'a Entity<EmojiPicker>,
+    pub emoji_open: bool,
 }
 
 /// Web `RegularCommentRow`: avatar · (name · relative time · [`…` menu]) over
@@ -240,6 +244,8 @@ pub(crate) fn comment_row(
                     .child(emoji_button(
                         SharedString::from(format!("comment-edit-emoji-{comment_id}")),
                         PendingScope::Edit,
+                        props.emoji_picker,
+                        props.emoji_open,
                         cx,
                     ))
                     .child(attach_button(
@@ -355,6 +361,8 @@ pub(crate) fn composer_row(
     submitting: bool,
     has_draft: bool,
     pending: &[PendingCommentAttachment],
+    emoji_picker: &Entity<EmojiPicker>,
+    emoji_open: bool,
     cx: &mut gpui::Context<IssueTimeline>,
 ) -> impl IntoElement {
     let full = pending.len() >= MAX_COMMENT_ATTACHMENTS;
@@ -374,7 +382,13 @@ pub(crate) fn composer_row(
                 // placeholder width at some window sizes; a column stretches
                 // its child to the definite slot width instead.
                 .child(v_flex().flex_1().min_w_0().child(input.clone()))
-                .child(emoji_button("comment-emoji", PendingScope::Composer, cx))
+                .child(emoji_button(
+                    "comment-emoji",
+                    PendingScope::Composer,
+                    emoji_picker,
+                    emoji_open,
+                    cx,
+                ))
                 .child(attach_button(
                     "comment-attach",
                     PendingScope::Composer,
@@ -397,9 +411,17 @@ pub(crate) fn composer_row(
 
 /// EXP-551: the emoji trigger both comment composers grow — a smiley that
 /// opens the shared picker; a pick inserts the UNICODE at the cursor.
+///
+/// `picker`/`open` come from the timeline's `&self`, NEVER from
+/// `cx.entity().read(cx)`: this renders inside `IssueTimeline::render`, where
+/// gpui holds the entity's lease, so reading it back through the map is a
+/// guaranteed `double_lease_panic` (it aborted desktop 0.14.16 on every issue
+/// open).
 fn emoji_button(
     id: impl Into<gpui::ElementId>,
     scope: PendingScope,
+    picker: &Entity<EmojiPicker>,
+    open: bool,
     cx: &mut gpui::Context<IssueTimeline>,
 ) -> impl IntoElement {
     let id = id.into();
@@ -411,8 +433,8 @@ fn emoji_button(
             .web_icon_sm()
             .icon(Icon::new(registry::EDITOR_EMOJI).text_color(cx.theme().muted_foreground))
             .tooltip("Emoji"),
-        cx.entity().read(cx).emoji_picker().clone(),
-        cx.entity().read(cx).emoji_open(scope),
+        picker.clone(),
+        open,
         cx.listener(move |this, open: &bool, _window, cx| {
             this.set_emoji_open(scope, *open, cx);
         }),

--- a/apps/desktop/crates/ui/src/timeline.rs
+++ b/apps/desktop/crates/ui/src/timeline.rs
@@ -275,10 +275,6 @@ impl IssueTimeline {
 
     // -- emoji (EXP-551) ------------------------------------------------------
 
-    pub(crate) fn emoji_picker(&self) -> &Entity<crate::emoji_picker::EmojiPicker> {
-        &self.emoji_picker
-    }
-
     pub(crate) fn emoji_open(&self, scope: PendingScope) -> bool {
         self.emoji_open == Some(scope)
     }
@@ -956,6 +952,8 @@ impl Render for IssueTimeline {
                             now_epoch,
                             team_id: self.team_id.as_deref(),
                             images: &self.images,
+                            emoji_picker: &self.emoji_picker,
+                            emoji_open: self.emoji_open(PendingScope::Edit),
                         },
                         cx,
                     );
@@ -972,6 +970,8 @@ impl Render for IssueTimeline {
             self.submitting,
             has_draft,
             &self.pending_attachments,
+            &self.emoji_picker,
+            self.emoji_open(PendingScope::Composer),
             cx,
         );
         // The hairline separating the activity section from the description
@@ -1250,6 +1250,37 @@ fn event_row(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// Desktop 0.14.16 aborted on EVERY issue open: the composer's emoji
+    /// button read the timeline back through `cx.entity().read(cx)` while
+    /// `render` held the entity's lease (gpui `double_lease_panic`). No synced
+    /// issue is needed to reproduce — the composer row renders regardless —
+    /// so this draws a bare timeline under an empty Store and must not panic.
+    #[gpui::test]
+    async fn a_bare_timeline_renders_without_a_double_lease(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            gpui_component::init(cx);
+            theme::init(cx);
+            let store = Store::open(cx, None, None);
+            cx.set_global(store);
+        });
+        let (view, cx) = cx.add_window_view(|window, cx| IssueTimeline::new(window, cx));
+        for _ in 0..2 {
+            cx.update(|window, cx| window.draw(cx).clear(cx));
+            cx.run_until_parked();
+        }
+        // Open the composer's picker and draw again: the Edit/Composer open
+        // flags ride the same `&self` path.
+        cx.update(|_window, cx| {
+            view.update(cx, |view, cx| {
+                view.set_emoji_open(PendingScope::Composer, true, cx);
+            });
+        });
+        cx.update(|window, cx| window.draw(cx).clear(cx));
+        view.read_with(cx, |view, _| {
+            assert!(view.emoji_open(PendingScope::Composer));
+        });
+    }
 
     /// The separator must vanish with the time — `relative_time` returns `""`
     /// for a missing/unparseable `created_at`, and a dangling " · " is what

--- a/apps/web/src/lib/changelog.ts
+++ b/apps/web/src/lib/changelog.ts
@@ -25,6 +25,13 @@ export interface ChangelogEntry {
 // Newest first.
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    id: `2026-08-desktop-issue-open-crash`,
+    date: `2026-08-19`,
+    title: `Desktop hotfix: opening an issue`,
+    summary: `Desktop 0.14.17 fixes a crash that closed the app whenever an issue was opened.`,
+    body: `- **Desktop crash fix**: opening an issue in the desktop app no longer closes it. The comment composer's emoji button (from the previous release) tripped an internal render check on every issue view; 0.14.17 repairs it, and the desktop app updates itself.`,
+  },
+  {
     id: `2026-08-comment-files-paused-sessions`,
     date: `2026-08-19`,
     title: `Files on comments, paused sessions, getting started`,

--- a/packages/licenses/inventory/rust-excluded.json
+++ b/packages/licenses/inventory/rust-excluded.json
@@ -8,11 +8,11 @@
       "reason": "not in the resolved graph for any target in deny.toml — an optional or platform-gated dependency cargo never builds for us"
     },
     {
-      "package": "api@0.14.16",
+      "package": "api@0.14.17",
       "reason": "workspace member — Exponential's own Apache-2.0 code, covered by the repository LICENSE"
     },
     {
-      "package": "app@0.14.16",
+      "package": "app@0.14.17",
       "reason": "workspace member — Exponential's own Apache-2.0 code, covered by the repository LICENSE"
     },
     {
@@ -28,7 +28,7 @@
       "reason": "not in the resolved graph for any target in deny.toml — an optional or platform-gated dependency cargo never builds for us"
     },
     {
-      "package": "coding@0.14.16",
+      "package": "coding@0.14.17",
       "reason": "workspace member — Exponential's own Apache-2.0 code, covered by the repository LICENSE"
     },
     {
@@ -56,7 +56,7 @@
       "reason": "not in the resolved graph for any target in deny.toml — an optional or platform-gated dependency cargo never builds for us"
     },
     {
-      "package": "domain@0.14.16",
+      "package": "domain@0.14.17",
       "reason": "workspace member — Exponential's own Apache-2.0 code, covered by the repository LICENSE"
     },
     {
@@ -64,7 +64,7 @@
       "reason": "not in the resolved graph for any target in deny.toml — an optional or platform-gated dependency cargo never builds for us"
     },
     {
-      "package": "exp-cli@0.14.16",
+      "package": "exp-cli@0.14.17",
       "reason": "workspace member — Exponential's own Apache-2.0 code, covered by the repository LICENSE"
     },
     {
@@ -216,11 +216,11 @@
       "reason": "not in the resolved graph for any target in deny.toml — an optional or platform-gated dependency cargo never builds for us"
     },
     {
-      "package": "steer@0.14.16",
+      "package": "steer@0.14.17",
       "reason": "workspace member — Exponential's own Apache-2.0 code, covered by the repository LICENSE"
     },
     {
-      "package": "sync@0.14.16",
+      "package": "sync@0.14.17",
       "reason": "workspace member — Exponential's own Apache-2.0 code, covered by the repository LICENSE"
     },
     {
@@ -240,11 +240,11 @@
       "reason": "not in the resolved graph for any target in deny.toml — an optional or platform-gated dependency cargo never builds for us"
     },
     {
-      "package": "terminal@0.14.16",
+      "package": "terminal@0.14.17",
       "reason": "workspace member — Exponential's own Apache-2.0 code, covered by the repository LICENSE"
     },
     {
-      "package": "theme@0.14.16",
+      "package": "theme@0.14.17",
       "reason": "workspace member — Exponential's own Apache-2.0 code, covered by the repository LICENSE"
     },
     {
@@ -264,7 +264,7 @@
       "reason": "not in the resolved graph for any target in deny.toml — an optional or platform-gated dependency cargo never builds for us"
     },
     {
-      "package": "ui@0.14.16",
+      "package": "ui@0.14.17",
       "reason": "workspace member — Exponential's own Apache-2.0 code, covered by the repository LICENSE"
     },
     {
@@ -272,7 +272,7 @@
       "reason": "not in the resolved graph for any target in deny.toml — an optional or platform-gated dependency cargo never builds for us"
     },
     {
-      "package": "updater@0.14.16",
+      "package": "updater@0.14.17",
       "reason": "workspace member — Exponential's own Apache-2.0 code, covered by the repository LICENSE"
     },
     {


### PR DESCRIPTION
## Summary
- Desktop 0.14.16 aborted on every issue open: `emoji_button` (EXP-551, `crates/ui/src/comments.rs`) called `cx.entity().read(cx)` on the `IssueTimeline` during its own render, while gpui held the entity lease → `double_lease_panic`.
- Fix: the picker handle and open flag are passed in from `&self` (`composer_row` params + `CommentRowProps`); the `emoji_picker()` accessor is removed.
- Regression `#[gpui::test]` draws a bare timeline under an empty `Store` and toggles the composer popover; verified to reproduce the panic against the old read.
- Release bump: desktop 0.14.17 (Cargo version + lockfile, `rust-excluded.json` regenerated, changelog entry).

Closes EXP-565.

## Test plan
- [x] `cargo check -p ui`, `cargo test -p ui` (482 pass; `markdown_view_sweep_selects_across_views` fails on HEAD too, env-only)
- [x] web `changelog` + `third-party-licences` tests
- [ ] CI green, then tag `desktop-v0.14.17`

🤖 Generated with [Claude Code](https://claude.com/claude-code)