### PR TITLE
EXP-616: web glass overhaul — the iOS carded look and feel

### DIFF
--- a/apps/android/app/src/main/java/com/exponential/app/data/api/ActionsApi.kt
+++ b/apps/android/app/src/main/java/com/exponential/app/data/api/ActionsApi.kt
@@ -89,7 +89,7 @@ fun builtinCreateAction(teamId: String): ActionDto = ActionDto(
             label = "Name",
             type = "text",
             required = false,
-            placeholder = "Leave blank to let the agent name it",
+            placeholder = "Name (optional)",
         ),
         ActionInputDto(
             key = "repo",

--- a/apps/android/app/src/main/java/com/exponential/app/ui/actions/CreateActionSheet.kt
+++ b/apps/android/app/src/main/java/com/exponential/app/ui/actions/CreateActionSheet.kt
@@ -260,7 +260,7 @@ fun CreateActionSheet(
                                 name = it.take(DomainContract.actionInputTextMax)
                             },
                             modifier = Modifier.weight(1f),
-                            placeholder = "Leave blank to let the agent name it",
+                            placeholder = "Name (optional)",
                             singleLine = true,
                         )
                     }

--- a/apps/android/app/src/test/java/com/exponential/app/data/api/BuiltinActionTeamIdTest.kt
+++ b/apps/android/app/src/test/java/com/exponential/app/data/api/BuiltinActionTeamIdTest.kt
@@ -74,7 +74,7 @@ class BuiltinActionTeamIdTest {
         assertEquals("Name", name.label)
         assertEquals("text", name.type)
         assertEquals(false, name.required)
-        assertEquals("Leave blank to let the agent name it", name.placeholder)
+        assertEquals("Name (optional)", name.placeholder)
     }
 
     @Test

--- a/apps/desktop/crates/api/src/actions.rs
+++ b/apps/desktop/crates/api/src/actions.rs
@@ -318,7 +318,7 @@ pub fn builtin_create_action(team_id: &str) -> Action {
                 label: "Name".to_string(),
                 input_type: "text".to_string(),
                 required: false,
-                placeholder: Some("Leave blank to let the agent name it".to_string()),
+                placeholder: Some("Name (optional)".to_string()),
             },
             ActionInput {
                 key: "repo".to_string(),
@@ -703,7 +703,7 @@ mod tests {
         assert!(!builtin.inputs[1].required);
         assert_eq!(
             builtin.inputs[1].placeholder.as_deref(),
-            Some("Leave blank to let the agent name it")
+            Some("Name (optional)")
         );
         assert_eq!(builtin.inputs[2].input_type, "repo");
         assert_eq!(builtin.inputs[3].input_type, "icon");

--- a/apps/ios/ExpCore/Sources/API/ActionsApi.swift
+++ b/apps/ios/ExpCore/Sources/API/ActionsApi.swift
@@ -129,7 +129,7 @@ public extension ActionDto {
                     label: "Name",
                     type: "text",
                     required: false,
-                    placeholder: "Leave blank to let the agent name it"
+                    placeholder: "Name (optional)"
                 ),
                 ActionInputDto(key: "repo", label: "Repository", type: "repo", required: false),
                 // EXP-273: the author picks the new action's glyph up front.

--- a/apps/ios/ExpCore/Tests/BuiltinActionsTests.swift
+++ b/apps/ios/ExpCore/Tests/BuiltinActionsTests.swift
@@ -49,7 +49,7 @@ final class BuiltinActionsTests: XCTestCase {
         XCTAssertEqual(name.label, "Name")
         XCTAssertEqual(name.type, "text")
         XCTAssertFalse(name.isRequired)
-        XCTAssertEqual(name.placeholder, "Leave blank to let the agent name it")
+        XCTAssertEqual(name.placeholder, "Name (optional)")
     }
 
     func testChatCapabilityIsCapGated() {

--- a/apps/ios/Exponential/UI/Actions/CreateActionSheet.swift
+++ b/apps/ios/Exponential/UI/Actions/CreateActionSheet.swift
@@ -157,7 +157,7 @@ struct CreateActionSheet: View {
         Section {
             HStack(spacing: 12) {
                 IconPicker(selection: $icon, allowsNone: true)
-                TextField("Leave blank to let the agent name it", text: $name)
+                TextField("Name (optional)", text: $name)
                     .accessibilityIdentifier("create-action-name")
             }
         } header: {

--- a/apps/web/src/components/account/account-overview.tsx
+++ b/apps/web/src/components/account/account-overview.tsx
@@ -3,14 +3,7 @@ import { trpc } from "@/lib/trpc-client"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { getInitials } from "@/lib/utils"
 import { useSession } from "@/hooks/use-session"
-import { Label } from "@/components/ui/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+import { GlassGroup, GlassPickerRow } from "@/components/ui/glass-rows"
 
 // `Intl.supportedValuesOf` is ES2023 — the app targets ES2022, so it is read
 // through a widened type and treated as optional at runtime too (older
@@ -82,26 +75,22 @@ export function AccountOverview({
 
       {/* EXP-369: the account's clock — the daily digest's send hour is read
           in it. Captured from the browser on first load; explicit here. */}
-      <div className="flex items-center gap-3">
-        <div className="flex-1">
-          <Label htmlFor="timezone">Timezone</Label>
-          <p className="text-xs text-muted-foreground">
+      <GlassGroup>
+        <div className="flex flex-col">
+          <GlassPickerRow
+            label="Timezone"
+            value={timezone}
+            onValueChange={handleTimezone}
+            options={timezoneOptions(timezone).map((zone) => ({
+              value: zone,
+              label: zone,
+            }))}
+          />
+          <p className="px-4 pb-3 text-xs text-foreground/50">
             Used to schedule your daily digest email.
           </p>
         </div>
-        <Select value={timezone} onValueChange={handleTimezone}>
-          <SelectTrigger id="timezone" className="w-60">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {timezoneOptions(timezone).map((zone) => (
-              <SelectItem key={zone} value={zone}>
-                {zone}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
+      </GlassGroup>
     </div>
   )
 }

--- a/apps/web/src/components/account/api-keys-section.tsx
+++ b/apps/web/src/components/account/api-keys-section.tsx
@@ -162,7 +162,7 @@ export function ApiKeysSection({ initialKeys }: { initialKeys: ApiKeyRow[] }) {
               here too.
             </p>
           ) : (
-            <div className="space-y-1">
+            <div className="flex flex-col gap-2">
               {keys.map((row) => {
                 const isDeviceKey = Boolean(
                   row.name?.startsWith(DEVICE_KEY_PREFIX)
@@ -170,7 +170,7 @@ export function ApiKeysSection({ initialKeys }: { initialKeys: ApiKeyRow[] }) {
                 return (
                   <div
                     key={row.id}
-                    className="flex items-center gap-3 rounded-md border p-3"
+                    className="flex items-center gap-3 rounded-md border border-glass-stroke bg-glass-row p-3"
                   >
                     <div className="min-w-0 flex-1">
                       <div className="truncate text-sm font-medium">

--- a/apps/web/src/components/account/email-notifications-card.tsx
+++ b/apps/web/src/components/account/email-notifications-card.tsx
@@ -5,13 +5,6 @@ import { authClient } from "@/lib/auth/client"
 import type { NotificationType } from "@/lib/domain"
 import type { DigestCadence } from "@/lib/notification-email-policy"
 import { Button } from "@/components/ui/button"
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
 import { Switch } from "@/components/ui/switch"
 import {
   GlassGroup,
@@ -142,123 +135,126 @@ export function EmailNotificationsCard({
       .catch((err) => console.error(`[prefs] update failed:`, err))
   }
 
+  // EXP-616: no outer Card. A card wrapping the notice plus two glass groups
+  // read as three nested boxes; iOS-style the header is plain text
+  // (GlassSectionHeader's idiom, with a leading glyph and the master switch
+  // riding along) and the groups sit straight on the page background.
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-start gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-md border bg-muted">
-            <Mail className="h-5 w-5" />
-          </div>
-          <div className="flex-1">
-            <CardTitle>Email notifications</CardTitle>
-            <CardDescription>
-              Notifications still unread are bundled into one digest email.
-            </CardDescription>
-          </div>
-          <Switch
-            checked={emailEnabled}
-            onCheckedChange={handleEmailEnabled}
-            disabled={!transportConfigured}
-            aria-label="Email notifications"
-          />
+    <div className="space-y-3">
+      <div className="flex items-center gap-3 px-1 pt-1 pb-1">
+        <div className="flex h-10 w-10 items-center justify-center rounded-md border bg-muted">
+          <Mail className="h-5 w-5" />
         </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {!transportConfigured && (
-          <div className="rounded-md border bg-muted p-3 text-sm text-muted-foreground">
-            Email sending is not configured on this server. Set
-            <code className="mx-1 rounded bg-background px-1 py-0.5 text-xs">
-              AWS_SES_REGION
-            </code>
-            or
-            <code className="mx-1 rounded bg-background px-1 py-0.5 text-xs">
-              SMTP_HOST
-            </code>
-            to enable it.
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-foreground">
+            Email notifications
+          </p>
+          <p className="text-xs text-foreground/50">
+            Notifications still unread are bundled into one digest email.
+          </p>
+        </div>
+        <Switch
+          checked={emailEnabled}
+          onCheckedChange={handleEmailEnabled}
+          disabled={!transportConfigured}
+          aria-label="Email notifications"
+        />
+      </div>
+
+      {!transportConfigured && (
+        <div className="rounded-md border bg-muted p-3 text-sm text-muted-foreground">
+          Email sending is not configured on this server. Set
+          <code className="mx-1 rounded bg-background px-1 py-0.5 text-xs">
+            AWS_SES_REGION
+          </code>
+          or
+          <code className="mx-1 rounded bg-background px-1 py-0.5 text-xs">
+            SMTP_HOST
+          </code>
+          to enable it.
+        </div>
+      )}
+
+      {transportConfigured && !emailVerified && (
+        <div className="flex items-start gap-3 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+          <div className="flex-1 text-muted-foreground">
+            <p className="font-medium text-foreground">
+              Verify your email to receive digest emails
+            </p>
+            <p className="mt-0.5 text-xs">
+              Digests are never sent to an unverified address. In-app and push
+              notifications are unaffected.
+              {verifyState === `sent` &&
+                ` Verification email sent to ${emailPrefs.email}.`}
+              {verifyState === `error` &&
+                ` Couldn't send the verification email. Try again in a moment.`}
+            </p>
           </div>
-        )}
+          <Button
+            size="sm"
+            variant="outline"
+            className="shrink-0"
+            disabled={verifyState === `sending` || verifyState === `sent`}
+            onClick={() => void resendVerification()}
+          >
+            {verifyState === `sending`
+              ? `Sending…`
+              : verifyState === `sent`
+                ? `Sent`
+                : `Resend`}
+          </Button>
+        </div>
+      )}
 
-        {transportConfigured && !emailVerified && (
-          <div className="flex items-start gap-3 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
-            <div className="flex-1 text-muted-foreground">
-              <p className="font-medium text-foreground">
-                Verify your email to receive digest emails
-              </p>
-              <p className="mt-0.5 text-xs">
-                Digests are never sent to an unverified address. In-app and
-                push notifications are unaffected.
-                {verifyState === `sent` &&
-                  ` Verification email sent to ${emailPrefs.email}.`}
-                {verifyState === `error` &&
-                  ` Couldn't send the verification email. Try again in a moment.`}
-              </p>
-            </div>
-            <Button
-              size="sm"
-              variant="outline"
-              className="shrink-0"
-              disabled={verifyState === `sending` || verifyState === `sent`}
-              onClick={() => void resendVerification()}
-            >
-              {verifyState === `sending`
-                ? `Sending…`
-                : verifyState === `sent`
-                  ? `Sent`
-                  : `Resend`}
-            </Button>
-          </div>
-        )}
+      <GlassGroup>
+        {TYPE_ROWS.map((row) => (
+          <GlassToggleRow
+            key={row.type}
+            id={`type-${row.type}`}
+            label={row.label}
+            description={row.hint}
+            checked={typePrefs[row.type] !== false}
+            onCheckedChange={(next) => handleTypeToggle(row.type, next)}
+            disabled={!transportConfigured}
+          />
+        ))}
+      </GlassGroup>
 
-        <GlassGroup>
-          {TYPE_ROWS.map((row) => (
-            <GlassToggleRow
-              key={row.type}
-              id={`type-${row.type}`}
-              label={row.label}
-              description={row.hint}
-              checked={typePrefs[row.type] !== false}
-              onCheckedChange={(next) => handleTypeToggle(row.type, next)}
-              disabled={!transportConfigured}
-            />
-          ))}
-        </GlassGroup>
+      <GlassGroup>
+        <div className="flex flex-col">
+          <GlassPickerRow
+            label="Delivery"
+            value={digest}
+            onValueChange={(next) => handleDigest(next as DigestCadence)}
+            options={[
+              { value: `off`, label: `Hourly digest` },
+              { value: `daily`, label: `Daily digest` },
+            ]}
+            disabled={!transportConfigured || !emailEnabled}
+          />
+          <p className="px-4 pb-3 text-xs text-foreground/50">
+            How often the digest goes out.
+          </p>
+        </div>
 
-        <GlassGroup>
+        {digest === `daily` && (
           <div className="flex flex-col">
             <GlassPickerRow
-              label="Delivery"
-              value={digest}
-              onValueChange={(next) => handleDigest(next as DigestCadence)}
-              options={[
-                { value: `off`, label: `Hourly digest` },
-                { value: `daily`, label: `Daily digest` },
-              ]}
+              label="Send time"
+              value={String(digestHour)}
+              onValueChange={(next) => handleDigestHour(Number(next))}
+              options={HOUR_OPTIONS.map((hour) => ({
+                value: String(hour),
+                label: `${hour}:00`,
+              }))}
               disabled={!transportConfigured || !emailEnabled}
             />
             <p className="px-4 pb-3 text-xs text-foreground/50">
-              How often the digest goes out.
+              Full hours only, in your timezone.
             </p>
           </div>
-
-          {digest === `daily` && (
-            <div className="flex flex-col">
-              <GlassPickerRow
-                label="Send time"
-                value={String(digestHour)}
-                onValueChange={(next) => handleDigestHour(Number(next))}
-                options={HOUR_OPTIONS.map((hour) => ({
-                  value: String(hour),
-                  label: `${hour}:00`,
-                }))}
-                disabled={!transportConfigured || !emailEnabled}
-              />
-              <p className="px-4 pb-3 text-xs text-foreground/50">
-                Full hours only, in your timezone.
-              </p>
-            </div>
-          )}
-        </GlassGroup>
-      </CardContent>
-    </Card>
+        )}
+      </GlassGroup>
+    </div>
   )
 }

--- a/apps/web/src/components/account/email-notifications-card.tsx
+++ b/apps/web/src/components/account/email-notifications-card.tsx
@@ -12,16 +12,12 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import { Label } from "@/components/ui/label"
-import { Separator } from "@/components/ui/separator"
 import { Switch } from "@/components/ui/switch"
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+  GlassGroup,
+  GlassPickerRow,
+  GlassToggleRow,
+} from "@/components/ui/glass-rows"
 
 export type EmailPrefs = Awaited<
   ReturnType<typeof trpc.notifications.emailPrefs.query>
@@ -213,73 +209,55 @@ export function EmailNotificationsCard({
           </div>
         )}
 
-        <div className="space-y-3">
+        <GlassGroup>
           {TYPE_ROWS.map((row) => (
-            <div key={row.type} className="flex items-center gap-3">
-              <div className="flex-1">
-                <Label htmlFor={`type-${row.type}`}>{row.label}</Label>
-                <p className="text-xs text-muted-foreground">{row.hint}</p>
-              </div>
-              <Switch
-                id={`type-${row.type}`}
-                checked={typePrefs[row.type] !== false}
-                onCheckedChange={(next) => handleTypeToggle(row.type, next)}
-                disabled={!transportConfigured}
-              />
-            </div>
+            <GlassToggleRow
+              key={row.type}
+              id={`type-${row.type}`}
+              label={row.label}
+              description={row.hint}
+              checked={typePrefs[row.type] !== false}
+              onCheckedChange={(next) => handleTypeToggle(row.type, next)}
+              disabled={!transportConfigured}
+            />
           ))}
-        </div>
+        </GlassGroup>
 
-        <Separator />
-
-        <div className="flex items-center gap-3">
-          <div className="flex-1">
-            <Label>Delivery</Label>
-            <p className="text-xs text-muted-foreground">
+        <GlassGroup>
+          <div className="flex flex-col">
+            <GlassPickerRow
+              label="Delivery"
+              value={digest}
+              onValueChange={(next) => handleDigest(next as DigestCadence)}
+              options={[
+                { value: `off`, label: `Hourly digest` },
+                { value: `daily`, label: `Daily digest` },
+              ]}
+              disabled={!transportConfigured || !emailEnabled}
+            />
+            <p className="px-4 pb-3 text-xs text-foreground/50">
               How often the digest goes out.
             </p>
           </div>
-          <Select
-            value={digest}
-            onValueChange={(next) => handleDigest(next as DigestCadence)}
-            disabled={!transportConfigured || !emailEnabled}
-          >
-            <SelectTrigger className="w-40">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="off">Hourly digest</SelectItem>
-              <SelectItem value="daily">Daily digest</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
 
-        {digest === `daily` && (
-          <div className="flex items-center gap-3">
-            <div className="flex-1">
-              <Label>Send time</Label>
-              <p className="text-xs text-muted-foreground">
+          {digest === `daily` && (
+            <div className="flex flex-col">
+              <GlassPickerRow
+                label="Send time"
+                value={String(digestHour)}
+                onValueChange={(next) => handleDigestHour(Number(next))}
+                options={HOUR_OPTIONS.map((hour) => ({
+                  value: String(hour),
+                  label: `${hour}:00`,
+                }))}
+                disabled={!transportConfigured || !emailEnabled}
+              />
+              <p className="px-4 pb-3 text-xs text-foreground/50">
                 Full hours only, in your timezone.
               </p>
             </div>
-            <Select
-              value={String(digestHour)}
-              onValueChange={(next) => handleDigestHour(Number(next))}
-              disabled={!transportConfigured || !emailEnabled}
-            >
-              <SelectTrigger className="w-40">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {HOUR_OPTIONS.map((hour) => (
-                  <SelectItem key={hour} value={String(hour)}>
-                    {`${hour}:00`}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        )}
+          )}
+        </GlassGroup>
       </CardContent>
     </Card>
   )

--- a/apps/web/src/components/agent-session-row.tsx
+++ b/apps/web/src/components/agent-session-row.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type ReactNode } from "react"
 import { Link } from "@tanstack/react-router"
-import { GitMerge, LoaderCircle, MonitorPlay } from "lucide-react"
+import { GitMerge, LoaderCircle } from "lucide-react"
+import { conceptIcon } from "@/lib/icons.generated"
 import type { AgentSessionRow } from "@/hooks/use-agents-data"
 import {
   sessionDisplayState,
@@ -17,6 +18,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import { GlassRow } from "@/components/ui/glass-rows"
+
+// EXP-616: the trailing bare glyph that opens the linked issue — the iOS
+// carded row's secondary destination, a cross-client concept never a raw
+// lucide import.
+const IssueDetailsIcon = conceptIcon(`ui-info`)
 
 // The live coding-session row shared by the team Agents page and the Actions
 // page (EXP-253) — extracted from routes/t/$teamSlug/agents/index.tsx so both
@@ -186,14 +193,10 @@ function SessionMergeButton({
 
 export function SessionRow({
   row,
-  canWatch,
   teamSlug,
   onOpen,
 }: {
   row: AgentSessionRow
-  /** Whether the Watch button shows at all (own session + relay on —
-   *  EXP-312: live sessions are owner-only). */
-  canWatch: boolean
   teamSlug: string
   onOpen: () => void
 }) {
@@ -211,12 +214,13 @@ export function SessionRow({
 
   // FEED-15: the native two-line row — dot | identifier + title, then the
   // parked-state label + "device · started …" byline | icon-only Merge and
-  // Watch — instead of the old four-column grid whose inline state label
-  // collided with the buttons on phones. Every row is the caller's own
-  // (EXP-312), so the byline names the machine, never the person.
+  // the bare issue-details glyph — instead of the old four-column grid whose
+  // inline state label collided with the buttons on phones. Every row is the
+  // caller's own (EXP-312), so the byline names the machine, never the person.
   return (
-    <div
-      className={`group/row flex cursor-pointer items-center gap-3 border-b border-border/30 px-3 py-2 hover:bg-muted/50 ${paused ? `opacity-60` : ``}`}
+    <GlassRow
+      interactive
+      className={paused ? `opacity-60` : undefined}
       onClick={onOpen}
       data-testid={`agent-session-${issue?.identifier ?? session.id}`}
       title={paused ? `${device.label ?? `The device`} is offline` : undefined}
@@ -226,27 +230,16 @@ export function SessionRow({
       </span>
       <div className="min-w-0 flex-1">
         <div className="flex min-w-0 items-center gap-1.5 text-sm">
+          {/* EXP-616: plain text — the trailing info glyph owns issue
+              navigation now (iOS parity). */}
           <span className="shrink-0 font-mono text-xs text-muted-foreground">
-            {isAction ? (
-              `Action`
-            ) : issue && board ? (
-              <Link
-                to="/t/$teamSlug/boards/$boardSlug/issues/$issueIdentifier"
-                params={{
-                  teamSlug,
-                  boardSlug: board.slug,
-                  issueIdentifier: issue.identifier,
-                }}
-                onClick={(e) => e.stopPropagation()}
-                className="hover:underline"
-              >
-                {issue.identifier}
-              </Link>
-            ) : isBatch ? (
-              `Batch`
-            ) : (
-              `—`
-            )}
+            {isAction
+              ? `Action`
+              : issue && board
+                ? issue.identifier
+                : isBatch
+                  ? `Batch`
+                  : `—`}
           </span>
           <span className="truncate font-medium">
             {isAction
@@ -281,22 +274,22 @@ export function SessionRow({
             issueId={prIssue.id}
           />
         )}
-        {canWatch && (
-          <Button
-            variant="outline"
-            size="icon"
-            className="size-8"
-            aria-label="Watch session"
-            title="Watch"
-            onClick={(e) => {
-              e.stopPropagation()
-              onOpen()
+        {issue && board && (
+          <Link
+            to="/t/$teamSlug/boards/$boardSlug/issues/$issueIdentifier"
+            params={{
+              teamSlug,
+              boardSlug: board.slug,
+              issueIdentifier: issue.identifier,
             }}
+            onClick={(e) => e.stopPropagation()}
+            aria-label="Issue details"
+            className="flex size-8 shrink-0 items-center justify-center rounded-full text-foreground/70 hover:text-foreground"
           >
-            <MonitorPlay />
-          </Button>
+            <IssueDetailsIcon className="size-4" />
+          </Link>
         )}
       </div>
-    </div>
+    </GlassRow>
   )
 }

--- a/apps/web/src/components/agent-session.tsx
+++ b/apps/web/src/components/agent-session.tsx
@@ -2439,8 +2439,9 @@ function MessageComposer({
           rows={1}
           className={cn(
             `max-h-32 min-h-9 flex-1 resize-none border-none shadow-none focus-visible:ring-0`,
-            // dark: variant included so it beats the base dark:bg-input/30.
-            `bg-transparent dark:bg-transparent`
+            // The composer sits on the session's own surface, so it drops the
+            // stock Textarea's glass fill (EXP-616).
+            `bg-transparent`
           )}
         />
         <Button

--- a/apps/web/src/components/automation-dialog.tsx
+++ b/apps/web/src/components/automation-dialog.tsx
@@ -184,7 +184,10 @@ export function AutomationDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-h-[85dvh] sm:max-w-lg">
+      {/* EXP-616: a bottom sheet on mobile — the body is an ordinary
+          DialogBody, so the sheet follows its content and scrolls inside once
+          it hits the 92dvh cap. */}
+      <DialogContent mobileSheet className="sm:max-h-[85dvh] sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>
             {editing ? `Edit automation` : `New automation`}

--- a/apps/web/src/components/automation-dialog.tsx
+++ b/apps/web/src/components/automation-dialog.tsx
@@ -33,14 +33,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { Label } from "@/components/ui/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+import { GlassGroup, GlassPickerRow } from "@/components/ui/glass-rows"
 
 // The "New automation" / "Edit automation" form (EXP-583). Automations are
 // their own rows now, so this is a plain owner-only tRPC form: pick the
@@ -198,30 +191,32 @@ export function AutomationDialog({
           </DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={submit} className="flex min-h-0 flex-1 flex-col gap-4">
-          <DialogBody className="space-y-4">
+        <form onSubmit={submit} className="flex min-h-0 flex-1 flex-col gap-3">
+          <DialogBody className="space-y-3">
             <div className="space-y-2">
-              <Label htmlFor="automation-action">Action</Label>
-              <Select value={actionId} onValueChange={setActionId}>
-                <SelectTrigger id="automation-action" className="w-full">
-                  <SelectValue placeholder="Select an action" />
-                </SelectTrigger>
-                <SelectContent>
-                  {actionOptions.map((action) => {
+              {/* EXP-616: the grouped-form row — "Action" leads, the picked
+                  action trails. */}
+              <GlassGroup>
+                <GlassPickerRow
+                  label="Action"
+                  value={actionId}
+                  onValueChange={setActionId}
+                  placeholder="Select an action"
+                  options={actionOptions.map((action) => {
                     const ActionIcon = getActionIcon(action)
-                    return (
-                      <SelectItem
-                        key={action.id}
-                        value={action.id}
-                        disabled={hasRequiredInputs(action)}
-                      >
-                        <ActionIcon className="size-4 shrink-0" />
-                        {action.name}
-                      </SelectItem>
-                    )
+                    return {
+                      value: action.id,
+                      disabled: hasRequiredInputs(action),
+                      label: (
+                        <>
+                          <ActionIcon className="size-4 shrink-0" />
+                          {action.name}
+                        </>
+                      ),
+                    }
                   })}
-                </SelectContent>
-              </Select>
+                />
+              </GlassGroup>
               {actionOptions.length === 0 && (
                 <p className="text-xs text-muted-foreground">
                   No custom actions yet. Create one first, then automate it.

--- a/apps/web/src/components/automation-dialog.tsx
+++ b/apps/web/src/components/automation-dialog.tsx
@@ -185,8 +185,8 @@ export function AutomationDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* EXP-616: a bottom sheet on mobile — the body is an ordinary
-          DialogBody, so the sheet follows its content and scrolls inside once
-          it hits the 92dvh cap. */}
+          DialogBody, so it takes the fixed 94dvh detent's free height and
+          scrolls inside it, content anchored to the top. */}
       <DialogContent mobileSheet className="sm:max-h-[85dvh] sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>

--- a/apps/web/src/components/automation-section.tsx
+++ b/apps/web/src/components/automation-section.tsx
@@ -51,6 +51,14 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { GlassGroup, GlassPickerRow } from "@/components/ui/glass-rows"
+import { cn } from "@/lib/utils"
+
+// EXP-616: the glass dress for the sentence-shaped inline fields — a sentence
+// stays a sentence, so these keep their compact widths and only take the row
+// fill/stroke. The `dark:` prefix is required to beat the stock control's own
+// `dark:bg-input/30`.
+const GLASS_FIELD = `border-glass-stroke bg-glass-row shadow-none dark:bg-glass-row dark:hover:bg-glass-active/50`
 
 // The reusable Automation editing PIECES (EXP-530, reshaped in EXP-583 when
 // automations became their own rows): the trigger panes + event filters, the
@@ -211,7 +219,7 @@ export function AutomationTriggerFields({
               set({ interval: value as ActionScheduleInterval })
             }
           >
-            <SelectTrigger size="sm" className="w-24">
+            <SelectTrigger size="sm" className={cn(`w-24`, GLASS_FIELD)}>
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -229,7 +237,7 @@ export function AutomationTriggerFields({
               value={String(draft.weekday)}
               onValueChange={(value) => set({ weekday: Number(value) })}
             >
-              <SelectTrigger size="sm" className="w-32">
+              <SelectTrigger size="sm" className={cn(`w-32`, GLASS_FIELD)}>
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -246,7 +254,7 @@ export function AutomationTriggerFields({
               value={String(draft.dayOfMonth)}
               onValueChange={(value) => set({ dayOfMonth: Number(value) })}
             >
-              <SelectTrigger size="sm" className="w-24">
+              <SelectTrigger size="sm" className={cn(`w-24`, GLASS_FIELD)}>
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -263,7 +271,7 @@ export function AutomationTriggerFields({
             aria-label="Time of day"
             value={draft.time}
             onChange={(e) => set({ time: e.target.value })}
-            className="h-8 w-36"
+            className={cn(`h-8 w-36`, GLASS_FIELD)}
           />
         </div>
       )}
@@ -278,7 +286,7 @@ export function AutomationTriggerFields({
                 set({ event: value as ActionTriggerEvent })
               }
             >
-              <SelectTrigger size="sm" className="w-full max-w-56">
+              <SelectTrigger size="sm" className={cn(`w-full max-w-56`, GLASS_FIELD)}>
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -307,13 +315,11 @@ export function AutomationDevicePicker({
   deviceId,
   devices,
   onChange,
-  id = `automation-device`,
 }: {
   deviceId: string | null
   /** Automation-capable devices only (see `automationDevices`). */
   devices: SteerDevice[]
   onChange: (deviceId: string) => void
-  id?: string
 }) {
   if (devices.length === 0 && !deviceId) {
     return (
@@ -332,30 +338,37 @@ export function AutomationDevicePicker({
   const unknownDeviceId =
     deviceId && !devices.some((d) => d.deviceId === deviceId) ? deviceId : null
   return (
-    <div className="space-y-2">
-      <Label htmlFor={id}>Runs on</Label>
-      <Select value={deviceId ?? undefined} onValueChange={onChange}>
-        <SelectTrigger id={id} className="w-full">
-          <SelectValue placeholder="Select a device" />
-        </SelectTrigger>
-        <SelectContent>
-          {unknownDeviceId && (
-            <SelectItem value={unknownDeviceId}>
-              <span className="text-muted-foreground">{unknownDeviceId}</span>
-            </SelectItem>
-          )}
-          {/* EXP-615: no online dot here — every automation-capable machine is
-              equally bindable (a schedule catches up on reconnect), so the
-              live state belongs on the Automations tab's rows, not in the
-              picker. */}
-          {devices.map((device) => (
-            <SelectItem key={device.deviceId} value={device.deviceId}>
-              {device.deviceLabel || device.deviceId}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
+    // EXP-616: a grouped-form row — "Runs on" leads, the machine trails.
+    <GlassGroup>
+      <GlassPickerRow
+        label="Runs on"
+        value={deviceId ?? undefined}
+        onValueChange={onChange}
+        placeholder="Select a device"
+        options={[
+          ...(unknownDeviceId
+            ? [
+                {
+                  value: unknownDeviceId,
+                  label: (
+                    <span className="text-muted-foreground">
+                      {unknownDeviceId}
+                    </span>
+                  ),
+                },
+              ]
+            : []),
+          // EXP-615: no online dot here — every automation-capable machine is
+          // equally bindable (a schedule catches up on reconnect), so the
+          // live state belongs on the Automations tab's rows, not in the
+          // picker.
+          ...devices.map((device) => ({
+            value: device.deviceId,
+            label: device.deviceLabel || device.deviceId,
+          })),
+        ]}
+      />
+    </GlassGroup>
   )
 }
 
@@ -583,7 +596,11 @@ function FilterMultiSelect({
         <Button
           variant="outline"
           size="sm"
-          className={`h-8 font-normal ${selected.length === 0 ? `text-muted-foreground` : ``}`}
+          className={cn(
+            `h-8 font-normal`,
+            GLASS_FIELD,
+            selected.length === 0 && `text-muted-foreground`
+          )}
         >
           {summary}
         </Button>

--- a/apps/web/src/components/automation-section.tsx
+++ b/apps/web/src/components/automation-section.tsx
@@ -54,11 +54,9 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { GlassGroup, GlassPickerRow } from "@/components/ui/glass-rows"
 import { cn } from "@/lib/utils"
 
-// EXP-616: the glass dress for the sentence-shaped inline fields — a sentence
-// stays a sentence, so these keep their compact widths and only take the row
-// fill/stroke. The `dark:` prefix is required to beat the stock control's own
-// `dark:bg-input/30`.
-const GLASS_FIELD = `border-glass-stroke bg-glass-row shadow-none dark:bg-glass-row dark:hover:bg-glass-active/50`
+// EXP-616: Input/SelectTrigger carry the glass dress themselves now; only the
+// Button-backed multi-pickers below still need it spelled out.
+const GLASS_TRIGGER = `border-glass-stroke bg-glass-row shadow-none dark:bg-glass-row dark:hover:bg-glass-active/50`
 
 // The reusable Automation editing PIECES (EXP-530, reshaped in EXP-583 when
 // automations became their own rows): the trigger panes + event filters, the
@@ -219,7 +217,7 @@ export function AutomationTriggerFields({
               set({ interval: value as ActionScheduleInterval })
             }
           >
-            <SelectTrigger size="sm" className={cn(`w-24`, GLASS_FIELD)}>
+            <SelectTrigger size="sm" className="w-24">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -237,7 +235,7 @@ export function AutomationTriggerFields({
               value={String(draft.weekday)}
               onValueChange={(value) => set({ weekday: Number(value) })}
             >
-              <SelectTrigger size="sm" className={cn(`w-32`, GLASS_FIELD)}>
+              <SelectTrigger size="sm" className="w-32">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -254,7 +252,7 @@ export function AutomationTriggerFields({
               value={String(draft.dayOfMonth)}
               onValueChange={(value) => set({ dayOfMonth: Number(value) })}
             >
-              <SelectTrigger size="sm" className={cn(`w-24`, GLASS_FIELD)}>
+              <SelectTrigger size="sm" className="w-24">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -271,7 +269,7 @@ export function AutomationTriggerFields({
             aria-label="Time of day"
             value={draft.time}
             onChange={(e) => set({ time: e.target.value })}
-            className={cn(`h-8 w-36`, GLASS_FIELD)}
+            className="h-8 w-36"
           />
         </div>
       )}
@@ -286,7 +284,7 @@ export function AutomationTriggerFields({
                 set({ event: value as ActionTriggerEvent })
               }
             >
-              <SelectTrigger size="sm" className={cn(`w-full max-w-56`, GLASS_FIELD)}>
+              <SelectTrigger size="sm" className="w-full max-w-56">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -598,7 +596,7 @@ function FilterMultiSelect({
           size="sm"
           className={cn(
             `h-8 font-normal`,
-            GLASS_FIELD,
+            GLASS_TRIGGER,
             selected.length === 0 && `text-muted-foreground`
           )}
         >

--- a/apps/web/src/components/automations-tab.tsx
+++ b/apps/web/src/components/automations-tab.tsx
@@ -22,7 +22,6 @@ import {
   REQUIRED_INPUTS_HINT,
 } from "@/components/automation-dialog"
 import { AGENT_LABELS } from "@/components/launch-dialog/launch-options-pane"
-import { SectionLabel } from "@/components/agent-session-row"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -39,6 +38,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { GlassRow, GlassSectionHeader } from "@/components/ui/glass-rows"
 import { Switch } from "@/components/ui/switch"
 
 // The Automations tab (EXP-530; own rows since EXP-583): every synced
@@ -165,8 +165,8 @@ function AutomationRow({
   }
 
   return (
-    <div className="flex items-center gap-3 border-b border-border/30 px-3 py-2">
-      <RowIcon className="size-4 shrink-0 text-muted-foreground" />
+    <GlassRow>
+      <RowIcon className="size-4 shrink-0 text-foreground/70" />
       <div className="min-w-0 flex-1">
         <div className="flex min-w-0 items-center gap-1.5 text-sm">
           <span className="truncate font-medium">
@@ -216,7 +216,7 @@ function AutomationRow({
           onDelete={onDelete}
         />
       )}
-    </div>
+    </GlassRow>
   )
 }
 
@@ -324,76 +324,77 @@ export function AutomationsTab({
 
   if (actions === null) {
     return (
-      <div className="px-3 py-3 text-sm text-muted-foreground">Loading…</div>
+      <div className="px-1 py-3 text-sm text-muted-foreground">Loading…</div>
     )
   }
 
   return (
     <>
-      <div className="space-y-4">
+      <div className="space-y-6">
         <div>
-          <SectionLabel
+          <GlassSectionHeader
             label="Automations"
             count={automations.length}
             trailing={newButton}
           />
           {automations.length === 0 ? (
-            <div className="px-3 py-3 text-sm text-muted-foreground">
+            <div className="px-1 py-3 text-sm text-muted-foreground">
               No automations yet.
             </div>
           ) : (
-            automations.map((automation) => (
-              <AutomationRow
-                key={automation.id}
-                automation={automation}
-                action={actionById.get(automation.actionId)}
-                devices={devices}
-                isOwner={isOwner}
-                lastRun={lastRunByAutomation.get(automation.id)}
-                onEdit={() => {
-                  setEditing(automation)
-                  setDialogOpen(true)
-                }}
-                onDelete={() => setDeleteTarget(automation)}
-              />
-            ))
+            <div className="flex flex-col gap-2">
+              {automations.map((automation) => (
+                <AutomationRow
+                  key={automation.id}
+                  automation={automation}
+                  action={actionById.get(automation.actionId)}
+                  devices={devices}
+                  isOwner={isOwner}
+                  lastRun={lastRunByAutomation.get(automation.id)}
+                  onEdit={() => {
+                    setEditing(automation)
+                    setDialogOpen(true)
+                  }}
+                  onDelete={() => setDeleteTarget(automation)}
+                />
+              ))}
+            </div>
           )}
         </div>
 
         <div>
-          <SectionLabel
+          <GlassSectionHeader
             label="Recent automated runs"
             count={automatedRuns.length}
           />
           {automatedRuns.length === 0 ? (
-            <div className="px-3 py-3 text-sm text-muted-foreground">
+            <div className="px-1 py-3 text-sm text-muted-foreground">
               Nothing has fired yet.
             </div>
           ) : (
-            automatedRuns.slice(0, 10).map((session) => (
-              <div
-                key={session.id}
-                className="flex items-center gap-2 border-b border-border/30 px-3 py-2 text-sm"
-              >
-                <Badge
-                  variant="outline"
-                  className="shrink-0 gap-1 text-[0.625rem]"
-                >
-                  <AutomationIcon className="h-3 w-3" />
-                  Automated
-                </Badge>
-                <span className="min-w-0 flex-1 truncate">
-                  {session.actionName ??
-                    (session.actionId
-                      ? actionById.get(session.actionId)?.name
-                      : null) ??
-                    `Action`}
-                </span>
-                <span className="shrink-0 text-xs text-muted-foreground">
-                  {`${sessionStatusLabel(session.status)} · ${relativeTime(session.createdAt)}`}
-                </span>
-              </div>
-            ))
+            <div className="flex flex-col gap-2">
+              {automatedRuns.slice(0, 10).map((session) => (
+                <GlassRow key={session.id} className="gap-2 text-sm">
+                  <Badge
+                    variant="outline"
+                    className="shrink-0 gap-1 text-[0.625rem]"
+                  >
+                    <AutomationIcon className="h-3 w-3" />
+                    Automated
+                  </Badge>
+                  <span className="min-w-0 flex-1 truncate">
+                    {session.actionName ??
+                      (session.actionId
+                        ? actionById.get(session.actionId)?.name
+                        : null) ??
+                      `Action`}
+                  </span>
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {`${sessionStatusLabel(session.status)} · ${relativeTime(session.createdAt)}`}
+                  </span>
+                </GlassRow>
+              ))}
+            </div>
           )}
         </div>
       </div>

--- a/apps/web/src/components/helpdesk/support-inbox.tsx
+++ b/apps/web/src/components/helpdesk/support-inbox.tsx
@@ -37,6 +37,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
 import { conceptIcon } from "@/lib/icons.generated"
 
@@ -174,25 +175,28 @@ export function SupportInbox({
         {/* EXP-449: no page title — the tabs sit left-aligned like the
             Inbox's. */}
         <div className="flex items-center gap-1 border-b px-3 py-2.5">
-          {([`open`, `resolved`] as const).map((tab) => {
-            const TabIcon = TAB_ICON[tab]
-            return (
-              <Button
-                key={tab}
-                variant="ghost"
-                size="sm"
-                onClick={() => setFilter(tab)}
-                className={`h-7 gap-1.5 rounded-full px-3 text-xs capitalize ${
-                  filter === tab
-                    ? `bg-accent font-medium text-foreground`
-                    : `text-muted-foreground hover:text-foreground`
-                }`}
-              >
-                <TabIcon className="size-3 shrink-0" />
-                {tab}
-              </Button>
-            )
-          })}
+          <Tabs
+            value={filter}
+            onValueChange={(value) =>
+              setFilter(value as `open` | `resolved`)
+            }
+          >
+            <TabsList className="h-8">
+              {([`open`, `resolved`] as const).map((tab) => {
+                const TabIcon = TAB_ICON[tab]
+                return (
+                  <TabsTrigger
+                    key={tab}
+                    value={tab}
+                    className="gap-1.5 px-3 text-xs capitalize"
+                  >
+                    <TabIcon className="size-3 shrink-0" />
+                    {tab}
+                  </TabsTrigger>
+                )
+              })}
+            </TabsList>
+          </Tabs>
         </div>
         <div className={`flex-1 overflow-y-auto ${TAB_BAR_CLEARANCE}`}>
           {threads === null ? (
@@ -209,37 +213,41 @@ export function SupportInbox({
               </p>
             </div>
           ) : (
-            threads.map((thread) => (
-              <button
-                key={thread.id}
-                type="button"
-                onClick={() => setSelectedId(thread.id)}
-                className={`block w-full border-b px-3 py-2.5 text-left transition-colors hover:bg-accent/50 ${
-                  thread.id === selectedId ? `bg-accent/60` : ``
-                }`}
-              >
-                <div className="flex items-center gap-2">
-                  <span className="min-w-0 flex-1 truncate text-sm font-medium">
-                    {reporterLabel(thread)}
-                  </span>
-                  <span className="shrink-0 text-[0.65rem] text-muted-foreground">
-                    {relativeTime(thread.updatedAt)}
-                  </span>
-                  {thread.unread && (
-                    <span
-                      className="h-2 w-2 shrink-0 rounded-full bg-primary"
-                      aria-label="Awaiting reply"
-                    />
-                  )}
-                </div>
-                <p className="mt-0.5 truncate text-xs text-muted-foreground">
-                  {thread.lastMessage?.body ?? thread.title}
-                </p>
-              </button>
-            ))
+            <div className="flex flex-col gap-2 p-2">
+              {threads.map((thread) => (
+                <button
+                  key={thread.id}
+                  type="button"
+                  onClick={() => setSelectedId(thread.id)}
+                  className={`block w-full rounded-md border border-glass-stroke px-3 py-2.5 text-left transition-colors ${
+                    thread.id === selectedId
+                      ? `bg-glass-active`
+                      : `bg-glass-row hover:bg-glass-active/50`
+                  }`}
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                      {reporterLabel(thread)}
+                    </span>
+                    <span className="shrink-0 text-[0.65rem] text-muted-foreground">
+                      {relativeTime(thread.updatedAt)}
+                    </span>
+                    {thread.unread && (
+                      <span
+                        className="h-2 w-2 shrink-0 rounded-full bg-primary"
+                        aria-label="Awaiting reply"
+                      />
+                    )}
+                  </div>
+                  <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                    {thread.lastMessage?.body ?? thread.title}
+                  </p>
+                </button>
+              ))}
+            </div>
           )}
           {threads !== null && threads.length > 0 && hasMore && (
-            <div className="p-2">
+            <div className="px-2 pb-2">
               <Button
                 variant="ghost"
                 size="sm"
@@ -449,7 +457,7 @@ function ConversationPane({
                   key={message.id}
                   className={`max-w-[85%] rounded-2xl px-3.5 py-2.5 text-sm ${
                     isInbound
-                      ? `self-start rounded-bl-sm bg-muted`
+                      ? `self-start rounded-bl-sm border border-glass-stroke bg-glass-row`
                       : isInternal
                         ? `self-end rounded-br-sm border border-amber-500/40 bg-amber-500/10`
                         : `self-end rounded-br-sm bg-primary text-primary-foreground`
@@ -683,7 +691,7 @@ function ThreadDetails({
   return (
     <>
       <section>
-        <h2 className="mb-1.5 text-xs font-medium uppercase text-muted-foreground">
+        <h2 className="mb-1.5 text-sm font-medium text-foreground/70">
           Reporter
         </h2>
         <p className="text-sm font-medium">{reporterLabel(thread)}</p>
@@ -707,7 +715,7 @@ function ThreadDetails({
 
       {submission && (
         <section>
-          <h2 className="mb-1.5 text-xs font-medium uppercase text-muted-foreground">
+          <h2 className="mb-1.5 text-sm font-medium text-foreground/70">
             Context
           </h2>
           {submission.pageUrl && (
@@ -738,7 +746,7 @@ function ThreadDetails({
         issue &&
         board && (
           <section>
-            <h2 className="mb-1.5 text-xs font-medium uppercase text-muted-foreground">
+            <h2 className="mb-1.5 text-sm font-medium text-foreground/70">
               Linked issue
             </h2>
             <Link
@@ -760,7 +768,7 @@ function ThreadDetails({
         )
       ) : (
         <section>
-          <h2 className="mb-1.5 text-xs font-medium uppercase text-muted-foreground">
+          <h2 className="mb-1.5 text-sm font-medium text-foreground/70">
             Escalate
           </h2>
           <p className="mb-2 text-xs text-muted-foreground">

--- a/apps/web/src/components/inbox/inbox-view.tsx
+++ b/apps/web/src/components/inbox/inbox-view.tsx
@@ -76,6 +76,10 @@ type Group = IssueGroup | SupportGroup
 const GROUP_CAP = 100
 const GROUP_CHUNK = 200
 
+// EXP-616 — the glass row shell (ui/glass-rows.tsx GlassRow), inlined because
+// these rows ARE the <Link> and align items-start for the two-line body.
+const NOTIFICATION_ROW = `flex items-start gap-3 rounded-md border border-glass-stroke bg-glass-row px-3 py-2 transition-colors duration-fast hover:bg-glass-active/50`
+
 // Single Linear-style activity stream: one row per issue group, showing the
 // latest notification's sentence (titles are already full human sentences —
 // no composition, no actor avatar). Reviewing open PRs moved to the
@@ -215,7 +219,9 @@ export function InboxView({ teamSlug }: { teamSlug: string }) {
 
   return (
     <div className="mx-auto flex h-full w-full max-w-3xl flex-col px-4 py-4">
-      <div className={`flex-1 space-y-2 overflow-y-auto ${TAB_BAR_CLEARANCE}`}>
+      <div
+        className={`flex flex-1 flex-col gap-2 overflow-y-auto ${TAB_BAR_CLEARANCE}`}
+      >
         {groups.length === 0 ? (
           <EmptyState
             icon={CircleCheck}
@@ -233,7 +239,7 @@ export function InboxView({ teamSlug }: { teamSlug: string }) {
                   params={{ teamSlug: g.teamSlug ?? teamSlug }}
                   onClick={() => void markGroupRead(g)}
                   className={cn(
-                    `flex items-start gap-3 rounded-md border px-3 py-2 transition-colors hover:bg-accent/50`,
+                    NOTIFICATION_ROW,
                     g.unread === 0 && `opacity-60`
                   )}
                 >
@@ -280,10 +286,7 @@ export function InboxView({ teamSlug }: { teamSlug: string }) {
                   issueIdentifier: g.issue.identifier,
                 }}
                 onClick={() => void markGroupRead(g)}
-                className={cn(
-                  `flex items-start gap-3 rounded-md border px-3 py-2 transition-colors hover:bg-accent/50`,
-                  g.unread === 0 && `opacity-60`
-                )}
+                className={cn(NOTIFICATION_ROW, g.unread === 0 && `opacity-60`)}
               >
                 <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted">
                   <Icon className="h-3.5 w-3.5 text-muted-foreground" />

--- a/apps/web/src/components/issue-coding-rows.tsx
+++ b/apps/web/src/components/issue-coding-rows.tsx
@@ -70,6 +70,9 @@ const PR_ROW_CLASS = `flex min-w-0 items-center gap-2 rounded-md border border-g
 // EXP-184 split them: IssueCodingControl renders as the full-width main-column
 // row (variant='row', both viewports since EXP-568) or as the phone bottom
 // bar's circle (variant='fab'); IssuePrRow always stays a main-column row.
+// EXP-616 added variant='start': the bare "Start coding" capsule the issue
+// detail hangs off its properties card, which the 'row' variant therefore no
+// longer draws.
 
 /** PR-state pill — open emerald / merged purple / closed rose / draft secondary. */
 export function PrStateBadge({ state }: { state: string | null | undefined }) {
@@ -200,7 +203,12 @@ export function SessionStatusBadge({
   )
 }
 
-export type CodingControlVariant = `row` | `fab`
+/** `row` = the main-column glass rows (running session / merge / "no desktop
+ * online"), `fab` = the phone bar's circle, `start` = the bare "Start coding"
+ * capsule the issue detail's properties card hosts (EXP-616, desktop parity
+ * with the IDE — it renders NOTHING in the states the `row` variant covers, so
+ * the two mounts never draw the same affordance twice). */
+export type CodingControlVariant = `row` | `fab` | `start`
 
 // Sidebar merge affordance (EXP-268): full-width Merge button + confirm
 // dialog for an issue whose linked PR is open. Mirrors the reviews pages'
@@ -412,6 +420,9 @@ function AgentRow({
   const latestDevice = useSessionDevice(latest)
 
   if (latest) {
+    // A live session replaces the start affordance — the properties card's
+    // capsule steps aside for the running row below.
+    if (variant === `start`) return null
     const owner = users.find((u) => u.id === latest.userId)
     const paused = sessionIsPaused(
       sessionDisplayState(latest, issue.prState),
@@ -507,7 +518,9 @@ function AgentRow({
   // an ungated steer.myDevices round-trip.
   if (!isMember || !steerEnabled || !board.repositoryId) {
     // An open PR still deserves its Merge button (EXP-268) even when remote
-    // start can't render (steer off / repo-less board).
+    // start can't render (steer off / repo-less board) — a main-column row,
+    // never the properties card's capsule.
+    if (variant === `start`) return null
     if (isMember && variant === `row` && issue.prState === `open`) {
       return (
         <CodingRowStack>
@@ -549,8 +562,9 @@ function RemoteStartRow({
   if (remote.devices === null) return null
   if (remote.devices.length === 0) {
     // Nothing to start on: the phone bar simply drops the circle rather than
-    // spending one of its three slots on an explanation.
-    if (variant === `fab`) return null
+    // spending one of its three slots on an explanation, and the properties
+    // card drops its capsule — the row below carries the explanation.
+    if (variant === `fab` || variant === `start`) return null
     return (
       <CodingRowStack>
         <GlassRow className="flex-wrap gap-2 text-xs text-muted-foreground">
@@ -608,26 +622,38 @@ function RemoteStartRow({
     )
   }
 
-  return (
-    <CodingRowStack>
-      <GlassRow className="flex-wrap gap-2">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => setDialogOpen(true)}
-          disabled={busy}
-        >
-          {remote.starting ? <LoaderCircle className="animate-spin" /> : <MonitorUp />}
-          Start coding
-        </Button>
-        {issue.prState === `open` && <IssueMergeButton issue={issue} />}
-        {dialog}
+  // EXP-616: the start affordance is a capsule INSIDE the issue's properties
+  // card (desktop parity with the IDE) — no standalone row of its own.
+  if (variant === `start`) {
+    return (
+      <div className="flex min-w-0 items-center gap-2">
         {remote.sentTo && (
-          <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
-            <LoaderCircle className="size-3 animate-spin" />
+          <span className="hidden min-w-0 items-center gap-1.5 truncate text-xs text-muted-foreground lg:inline-flex">
+            <LoaderCircle className="size-3 shrink-0 animate-spin" />
             Start sent to {remote.sentTo}. Waiting for the desktop…
           </span>
         )}
+        <Button
+          variant="glass"
+          size="xs"
+          onClick={() => setDialogOpen(true)}
+          disabled={busy}
+        >
+          {busy ? <LoaderCircle className="animate-spin" /> : <MonitorUp />}
+          Start coding
+        </Button>
+        {dialog}
+      </div>
+    )
+  }
+
+  // The main column keeps only what the capsule can't carry: an open PR's
+  // Merge button (EXP-268). With nothing to show it draws no empty card.
+  if (issue.prState !== `open`) return null
+  return (
+    <CodingRowStack>
+      <GlassRow className="flex-wrap gap-2">
+        <IssueMergeButton issue={issue} />
       </GlassRow>
     </CodingRowStack>
   )

--- a/apps/web/src/components/issue-coding-rows.tsx
+++ b/apps/web/src/components/issue-coding-rows.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useState, type ReactNode } from "react"
 import { and, eq, inArray, useLiveQuery } from "@tanstack/react-db"
 import { Link } from "@tanstack/react-router"
 import {
@@ -33,6 +33,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import { GlassRow } from "@/components/ui/glass-rows"
 import { useSteerConfig } from "@/components/agent-session"
 import { useAgentDock } from "@/components/agent-dock/agent-dock-provider"
 import { useRemoteStart } from "@/hooks/use-remote-start"
@@ -47,6 +48,19 @@ const ActionRunIcon = conceptIcon(`action-run`)
 // EXP-568: the floating mobile bar's 52px circles (issue-detail-mobile-bar.tsx
 // owns the bar itself; the coding circle's gating lives here).
 const FAB_CIRCLE_CLASS = `pointer-events-auto flex size-[52px] shrink-0 items-center justify-center rounded-full border border-glass-stroke-card bg-popover/85 shadow-lg shadow-black/40 backdrop-blur-xl`
+
+// EXP-616: the coding / PR rows are glass CARDS now, not full-bleed
+// `border-t` divider rows. Both exported pieces mount as independent siblings
+// of the issue-detail main column (issue-detail-view.tsx owns no wrapper), so
+// each one carries its own stack + gutter — the same `px-5 py-2` gutter
+// issue-files-section.tsx uses, so the cards line up down the column.
+function CodingRowStack({ children }: { children: ReactNode }) {
+  return <div className="flex flex-col gap-2 px-5 py-2">{children}</div>
+}
+
+// The PR row is a <Link>, so it can't reuse the <GlassRow> div — same recipe,
+// interactive arm included.
+const PR_ROW_CLASS = `flex min-w-0 items-center gap-2 rounded-md border border-glass-stroke bg-glass-row p-3 text-sm transition-colors duration-fast hover:bg-glass-active/50`
 
 // The coding affordances of the issue detail (EXP-106): a compact "coding now"
 // / remote-start control that FOCUSES the global dock (never mounts the live
@@ -458,29 +472,31 @@ function AgentRow({
     )
 
     return (
-      <div className="flex min-w-0 flex-wrap items-center gap-2 border-t border-border px-4 py-3">
-        {codingBadge}
-        {ownerLabel}
-        {ownLatest && steerEnabled ? (
-          <Button
-            variant="outline"
-            size="sm"
-            className="ml-auto shrink-0"
-            onClick={() => dock?.openDock(ownLatest.id)}
-          >
-            <MonitorPlay />
-            Watch
-          </Button>
-        ) : ownLatest && steerEnabled === false ? (
-          <span className="ml-auto text-xs text-muted-foreground">
-            Live steering is unavailable on this instance.
-          </span>
-        ) : null}
-        {/* EXP-568: the sidebar is gone, so its Merge button lives here. */}
-        {isMember && issue.prState === `open` && (
-          <IssueMergeButton issue={issue} />
-        )}
-      </div>
+      <CodingRowStack>
+        <GlassRow className="min-w-0 flex-wrap gap-2">
+          {codingBadge}
+          {ownerLabel}
+          {ownLatest && steerEnabled ? (
+            <Button
+              variant="outline"
+              size="sm"
+              className="ml-auto shrink-0"
+              onClick={() => dock?.openDock(ownLatest.id)}
+            >
+              <MonitorPlay />
+              Watch
+            </Button>
+          ) : ownLatest && steerEnabled === false ? (
+            <span className="ml-auto text-xs text-muted-foreground">
+              Live steering is unavailable on this instance.
+            </span>
+          ) : null}
+          {/* EXP-568: the sidebar is gone, so its Merge button lives here. */}
+          {isMember && issue.prState === `open` && (
+            <IssueMergeButton issue={issue} />
+          )}
+        </GlassRow>
+      </CodingRowStack>
     )
   }
 
@@ -494,9 +510,11 @@ function AgentRow({
     // start can't render (steer off / repo-less board).
     if (isMember && variant === `row` && issue.prState === `open`) {
       return (
-        <div className="flex items-center gap-2 border-t border-border px-4 py-3">
-          <IssueMergeButton issue={issue} />
-        </div>
+        <CodingRowStack>
+          <GlassRow className="gap-2">
+            <IssueMergeButton issue={issue} />
+          </GlassRow>
+        </CodingRowStack>
       )
     }
     return null
@@ -534,12 +552,14 @@ function RemoteStartRow({
     // spending one of its three slots on an explanation.
     if (variant === `fab`) return null
     return (
-      <div className="flex flex-wrap items-center gap-2 border-t border-border px-4 py-3 text-xs text-muted-foreground">
-        <UiDeviceOfflineIcon className="size-3.5 shrink-0" />
-        No desktop online. Open the Exponential desktop app to run this issue
-        there.
-        {issue.prState === `open` && <IssueMergeButton issue={issue} />}
-      </div>
+      <CodingRowStack>
+        <GlassRow className="flex-wrap gap-2 text-xs text-muted-foreground">
+          <UiDeviceOfflineIcon className="size-3.5 shrink-0" />
+          No desktop online. Open the Exponential desktop app to run this issue
+          there.
+          {issue.prState === `open` && <IssueMergeButton issue={issue} />}
+        </GlassRow>
+      </CodingRowStack>
     )
   }
 
@@ -589,25 +609,27 @@ function RemoteStartRow({
   }
 
   return (
-    <div className="flex flex-wrap items-center gap-2 border-t border-border px-4 py-3">
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={() => setDialogOpen(true)}
-        disabled={busy}
-      >
-        {remote.starting ? <LoaderCircle className="animate-spin" /> : <MonitorUp />}
-        Start coding
-      </Button>
-      {issue.prState === `open` && <IssueMergeButton issue={issue} />}
-      {dialog}
-      {remote.sentTo && (
-        <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
-          <LoaderCircle className="size-3 animate-spin" />
-          Start sent to {remote.sentTo}. Waiting for the desktop…
-        </span>
-      )}
-    </div>
+    <CodingRowStack>
+      <GlassRow className="flex-wrap gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setDialogOpen(true)}
+          disabled={busy}
+        >
+          {remote.starting ? <LoaderCircle className="animate-spin" /> : <MonitorUp />}
+          Start coding
+        </Button>
+        {issue.prState === `open` && <IssueMergeButton issue={issue} />}
+        {dialog}
+        {remote.sentTo && (
+          <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+            <LoaderCircle className="size-3 animate-spin" />
+            Start sent to {remote.sentTo}. Waiting for the desktop…
+          </span>
+        )}
+      </GlassRow>
+    </CodingRowStack>
   )
 }
 
@@ -653,42 +675,44 @@ function PrRow({
     }
   }, [canProbe, issue.id])
 
-  const rowClass = `flex min-w-0 items-center gap-2 border-t border-border px-4 py-3 text-sm hover:bg-muted/50`
-
   if (hasPr) {
     return (
-      <Link
-        to="/t/$teamSlug/reviews/$issueIdentifier"
-        params={{ teamSlug, issueIdentifier: issue.identifier }}
-        className={rowClass}
-      >
-        <GitPullRequest className="size-4 shrink-0 text-muted-foreground" />
-        <PrStateBadge state={issue.prState} />
-        <span className="shrink-0 font-mono">PR #{issue.prNumber}</span>
-        {issue.branch && (
-          <span className="hidden truncate font-mono text-xs text-muted-foreground md:inline">
-            {issue.branch}
-          </span>
-        )}
-        <ChevronRight className="ml-auto size-4 shrink-0 text-muted-foreground" />
-      </Link>
+      <CodingRowStack>
+        <Link
+          to="/t/$teamSlug/reviews/$issueIdentifier"
+          params={{ teamSlug, issueIdentifier: issue.identifier }}
+          className={PR_ROW_CLASS}
+        >
+          <GitPullRequest className="size-4 shrink-0 text-muted-foreground" />
+          <PrStateBadge state={issue.prState} />
+          <span className="shrink-0 font-mono">PR #{issue.prNumber}</span>
+          {issue.branch && (
+            <span className="hidden truncate font-mono text-xs text-muted-foreground md:inline">
+              {issue.branch}
+            </span>
+          )}
+          <ChevronRight className="ml-auto size-4 shrink-0 text-muted-foreground" />
+        </Link>
+      </CodingRowStack>
     )
   }
 
   if (canProbe && branchFileCount != null && branchFileCount > 0) {
     return (
-      <Link
-        to="/t/$teamSlug/reviews/$issueIdentifier"
-        params={{ teamSlug, issueIdentifier: issue.identifier }}
-        className={rowClass}
-      >
-        <GitBranch className="size-4 shrink-0 text-muted-foreground" />
-        <span className="truncate">
-          Branch <span className="font-mono">exp/{issue.identifier}</span>
-          {` · no PR yet`}
-        </span>
-        <ChevronRight className="ml-auto size-4 shrink-0 text-muted-foreground" />
-      </Link>
+      <CodingRowStack>
+        <Link
+          to="/t/$teamSlug/reviews/$issueIdentifier"
+          params={{ teamSlug, issueIdentifier: issue.identifier }}
+          className={PR_ROW_CLASS}
+        >
+          <GitBranch className="size-4 shrink-0 text-muted-foreground" />
+          <span className="truncate">
+            Branch <span className="font-mono">exp/{issue.identifier}</span>
+            {` · no PR yet`}
+          </span>
+          <ChevronRight className="ml-auto size-4 shrink-0 text-muted-foreground" />
+        </Link>
+      </CodingRowStack>
     )
   }
 

--- a/apps/web/src/components/issue-detail-view.tsx
+++ b/apps/web/src/components/issue-detail-view.tsx
@@ -505,10 +505,11 @@ export function IssueDetailView({
 
   const dueDate = issue.dueDate ? parseLocalDate(issue.dueDate) : undefined
 
-  // Coding "coding now" / remote-start control (EXP-184): a main-column row on
-  // desktop, one circle in the floating bar on phones (EXP-568). The component
-  // owns the repo/membership/relay gating and focuses the global dock rather
-  // than mounting the live viewer inline.
+  // Coding "coding now" row (EXP-184): a main-column row on desktop, one
+  // circle in the floating bar on phones (EXP-568). The component owns the
+  // repo/membership/relay gating and focuses the global dock rather than
+  // mounting the live viewer inline. Since EXP-616 the IDLE start affordance
+  // moved out of this row and into the properties card below.
   const codingControl =
     currentUserId && !isMobile ? (
       <IssueCodingControl
@@ -530,6 +531,22 @@ export function IssueDetailView({
         currentUserId={currentUserId}
         users={users}
         variant="fab"
+      />
+    ) : null
+
+  // EXP-616: "Start coding" is a capsule at the trailing end of the properties
+  // card (desktop parity with the IDE) — it no longer gets a row of its own
+  // below the description. Desktop only: on phones the floating bar's circle
+  // still owns the start, and the properties card there is the same node.
+  const codingStartButton =
+    currentUserId && !isMobile ? (
+      <IssueCodingControl
+        issue={issue}
+        board={board}
+        teamId={teamId}
+        currentUserId={currentUserId}
+        users={users}
+        variant="start"
       />
     ) : null
 
@@ -602,8 +619,13 @@ export function IssueDetailView({
   // band welded to the header.
   const propsBand = (
     <div className="mx-auto w-full max-w-3xl px-4 pt-3">
-      <div className="rounded-xl border border-glass-stroke-card bg-popover/40">
-        {propsPanel}
+      <div className="flex items-center gap-1.5 rounded-xl border border-glass-stroke-card bg-popover/40">
+        <div className="min-w-0 flex-1">{propsPanel}</div>
+        {/* min-w-0, not shrink-0: the "waiting for the desktop" caption beside
+            the capsule truncates rather than squeezing the property pills. */}
+        {codingStartButton && (
+          <div className="min-w-0 pr-3">{codingStartButton}</div>
+        )}
       </div>
     </div>
   )

--- a/apps/web/src/components/launch-dialog/action-input-fields.tsx
+++ b/apps/web/src/components/launch-dialog/action-input-fields.tsx
@@ -29,13 +29,8 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { BoardGlyph } from "@/components/board-glyph"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+import { GlassGroup, GlassPickerRow } from "@/components/ui/glass-rows"
+import { cn } from "@/lib/utils"
 
 // The selected action's typed input fields (EXP-257): text → plain Input,
 // repo → compact Select over the team's connected repos, board → a
@@ -51,6 +46,10 @@ import {
 // Radix Select forbids an empty-string item value; the unset optional repo
 // rides this sentinel inside the dialog only.
 const NO_REPO = `none`
+
+// EXP-616: the glass dress for a free-text field — the `dark:` prefix is
+// required to beat the stock input/textarea's own `dark:bg-input/30`.
+const GLASS_FIELD = `border-glass-stroke bg-glass-row shadow-none dark:bg-glass-row`
 
 export function ActionInputFields({
   defs,
@@ -84,6 +83,7 @@ export function ActionInputFields({
                 value={values[def.key] ?? ``}
                 onChange={(e) => onChange(def.key, e.target.value)}
                 placeholder={def.placeholder}
+                className={GLASS_FIELD}
                 // Client parity with the server's per-value cap, so a long
                 // paste is refused at the field instead of at submit.
                 maxLength={MAX_ACTION_INPUT_TEXT}
@@ -102,37 +102,34 @@ export function ActionInputFields({
                 value={values[def.key] ?? ``}
                 onChange={(e) => onChange(def.key, e.target.value)}
                 placeholder={def.placeholder}
-                className="min-h-24"
+                className={cn(`min-h-24`, GLASS_FIELD)}
                 maxLength={MAX_ACTION_INPUT_TEXT}
               />
             </div>
           )
         }
         if (def.type === `repo`) {
+          // EXP-616: a pure single-select carries its label INSIDE the row
+          // (the iOS grouped-form shape); the free-text fields above keep
+          // their label above, where a long placeholder needs the width.
           return (
-            <div key={def.key} className="space-y-2">
-              <Label htmlFor={fieldId}>{label}</Label>
-              <Select
+            <GlassGroup key={def.key}>
+              <GlassPickerRow
+                label={label}
                 value={values[def.key] || (def.required ? `` : NO_REPO)}
                 onValueChange={(value) =>
                   onChange(def.key, value === NO_REPO ? `` : value)
                 }
-              >
-                <SelectTrigger id={fieldId} className="w-full">
-                  <SelectValue placeholder="Select a repository" />
-                </SelectTrigger>
-                <SelectContent>
-                  {!def.required && (
-                    <SelectItem value={NO_REPO}>None</SelectItem>
-                  )}
-                  {repos.map((repo) => (
-                    <SelectItem key={repo.id} value={repo.id}>
-                      {repo.fullName}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+                placeholder="Select a repository"
+                options={[
+                  ...(def.required ? [] : [{ value: NO_REPO, label: `None` }]),
+                  ...repos.map((repo) => ({
+                    value: repo.id,
+                    label: repo.fullName,
+                  })),
+                ]}
+              />
+            </GlassGroup>
           )
         }
         if (def.type === `pr`) {
@@ -250,7 +247,7 @@ function PrInputField({
       <MobilePopoverTrigger asChild>
         <Button
           variant="outline"
-          className="w-full justify-start font-normal"
+          className={cn(`w-full justify-start font-normal`, GLASS_FIELD)}
         >
           {selected ? (
             <span className="min-w-0 truncate">{selected.label}</span>
@@ -347,7 +344,7 @@ function BoardInputField({
       <MobilePopoverTrigger asChild>
         <Button
           variant="outline"
-          className="w-full justify-start font-normal"
+          className={cn(`w-full justify-start font-normal`, GLASS_FIELD)}
         >
           {selected ? (
             <>

--- a/apps/web/src/components/launch-dialog/action-input-fields.tsx
+++ b/apps/web/src/components/launch-dialog/action-input-fields.tsx
@@ -47,9 +47,9 @@ import { cn } from "@/lib/utils"
 // rides this sentinel inside the dialog only.
 const NO_REPO = `none`
 
-// EXP-616: the glass dress for a free-text field — the `dark:` prefix is
-// required to beat the stock input/textarea's own `dark:bg-input/30`.
-const GLASS_FIELD = `border-glass-stroke bg-glass-row shadow-none dark:bg-glass-row`
+// EXP-616: Input/Textarea/SelectTrigger are glass on their own now; only the
+// Button-backed pickers below still need the field dress spelled out.
+const GLASS_TRIGGER = `border-glass-stroke bg-glass-row shadow-none dark:bg-glass-row`
 
 export function ActionInputFields({
   defs,
@@ -83,7 +83,6 @@ export function ActionInputFields({
                 value={values[def.key] ?? ``}
                 onChange={(e) => onChange(def.key, e.target.value)}
                 placeholder={def.placeholder}
-                className={GLASS_FIELD}
                 // Client parity with the server's per-value cap, so a long
                 // paste is refused at the field instead of at submit.
                 maxLength={MAX_ACTION_INPUT_TEXT}
@@ -102,7 +101,7 @@ export function ActionInputFields({
                 value={values[def.key] ?? ``}
                 onChange={(e) => onChange(def.key, e.target.value)}
                 placeholder={def.placeholder}
-                className={cn(`min-h-24`, GLASS_FIELD)}
+                className="min-h-24"
                 maxLength={MAX_ACTION_INPUT_TEXT}
               />
             </div>
@@ -247,7 +246,7 @@ function PrInputField({
       <MobilePopoverTrigger asChild>
         <Button
           variant="outline"
-          className={cn(`w-full justify-start font-normal`, GLASS_FIELD)}
+          className={cn(`w-full justify-start font-normal`, GLASS_TRIGGER)}
         >
           {selected ? (
             <span className="min-w-0 truncate">{selected.label}</span>
@@ -344,7 +343,7 @@ function BoardInputField({
       <MobilePopoverTrigger asChild>
         <Button
           variant="outline"
-          className={cn(`w-full justify-start font-normal`, GLASS_FIELD)}
+          className={cn(`w-full justify-start font-normal`, GLASS_TRIGGER)}
         >
           {selected ? (
             <>

--- a/apps/web/src/components/launch-dialog/actions-pane.tsx
+++ b/apps/web/src/components/launch-dialog/actions-pane.tsx
@@ -63,9 +63,9 @@ export function ActionsPane({
           value={search}
           onChange={(e) => onSearchChange(e.target.value)}
           placeholder="Search actions…"
-          // EXP-616: the glass field dress — the `dark:` prefix is required to
-          // beat the stock input's own `dark:bg-input/30`.
-          className="h-9 rounded-md border-glass-stroke bg-glass-row pl-8 shadow-none dark:bg-glass-row"
+          // The glass dress is the stock Input's own (EXP-616); only the
+          // leading room for the search glyph is local.
+          className="h-9 rounded-md pl-8"
         />
       </div>
       <div className="max-h-44 overflow-y-auto rounded-lg border-0 bg-glass-row sm:max-h-none sm:min-h-32 sm:flex-1">

--- a/apps/web/src/components/launch-dialog/actions-pane.tsx
+++ b/apps/web/src/components/launch-dialog/actions-pane.tsx
@@ -63,10 +63,12 @@ export function ActionsPane({
           value={search}
           onChange={(e) => onSearchChange(e.target.value)}
           placeholder="Search actions…"
-          className="h-9 pl-8"
+          // EXP-616: the glass field dress — the `dark:` prefix is required to
+          // beat the stock input's own `dark:bg-input/30`.
+          className="h-9 rounded-md border-glass-stroke bg-glass-row pl-8 shadow-none dark:bg-glass-row"
         />
       </div>
-      <div className="max-h-44 overflow-y-auto rounded-md border border-border sm:max-h-none sm:min-h-32 sm:flex-1">
+      <div className="max-h-44 overflow-y-auto rounded-lg border-0 bg-glass-row sm:max-h-none sm:min-h-32 sm:flex-1">
         {actions === null ? (
           <div className="px-3 py-6 text-center text-xs text-muted-foreground">
             Loading…
@@ -92,8 +94,8 @@ export function ActionsPane({
                   }
                 }}
                 className={cn(
-                  `flex cursor-pointer items-center gap-2 border-b border-border/30 px-3 py-2 last:border-b-0`,
-                  selected ? `bg-muted` : `hover:bg-muted/50`
+                  `flex cursor-pointer items-center gap-2 border-b border-glass-stroke px-3 py-2 last:border-b-0`,
+                  selected ? `bg-glass-active` : `hover:bg-glass-active/50`
                 )}
               >
                 <RowIcon className="size-4 shrink-0 text-muted-foreground" />

--- a/apps/web/src/components/launch-dialog/chat-pane.tsx
+++ b/apps/web/src/components/launch-dialog/chat-pane.tsx
@@ -47,7 +47,7 @@ export function ChatPane({
           value={prompt}
           onChange={(e) => onPromptChange(e.target.value)}
           placeholder={promptDef?.placeholder}
-          className="min-h-28 border-0 bg-transparent px-0 shadow-none focus-visible:ring-0 dark:bg-transparent sm:h-full sm:min-h-0 sm:flex-1"
+          className="min-h-28 border-0 bg-transparent px-0 shadow-none focus-visible:ring-0 sm:h-full sm:min-h-0 sm:flex-1"
           // Client parity with the server's per-value cap, so a long paste is
           // refused at the field instead of at submit.
           maxLength={MAX_ACTION_INPUT_TEXT}

--- a/apps/web/src/components/launch-dialog/chat-pane.tsx
+++ b/apps/web/src/components/launch-dialog/chat-pane.tsx
@@ -3,13 +3,7 @@ import { MAX_ACTION_INPUT_TEXT } from "@exp/db-schema/domain"
 import { builtinChatAction } from "@/lib/builtin-actions"
 import type { ActionRepoOption } from "@/components/action-editor-dialog"
 import { Label } from "@/components/ui/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+import { GlassGroup, GlassPickerRow } from "@/components/ui/glass-rows"
 import { Textarea } from "@/components/ui/textarea"
 
 // The Chat tab of the unified launch dialog (EXP-615): a free prompt on a
@@ -40,41 +34,46 @@ export function ChatPane({
   return (
     // Shrink only under `sm:` — see the actions pane's note (EXP-313).
     <div className="flex shrink-0 flex-col gap-3 sm:min-h-0 sm:shrink">
-      <div className="flex min-h-0 flex-col gap-2 sm:flex-1">
-        <Label htmlFor="chat-prompt">Prompt</Label>
+      {/* EXP-616: the prompt is its OWN glass card — caption-sized label,
+          borderless field. The desktop column's stretch lives on the CARD now,
+          the textarea just fills it. */}
+      <div className="flex min-h-0 flex-col gap-1 rounded-lg bg-glass-row p-3 sm:flex-1">
+        <Label htmlFor="chat-prompt" className="text-xs text-foreground/50">
+          Prompt
+        </Label>
         <Textarea
           id="chat-prompt"
           autoFocus
           value={prompt}
           onChange={(e) => onPromptChange(e.target.value)}
           placeholder={promptDef?.placeholder}
-          className="min-h-28 sm:h-full sm:min-h-0 sm:flex-1"
+          className="min-h-28 border-0 bg-transparent px-0 shadow-none focus-visible:ring-0 dark:bg-transparent sm:h-full sm:min-h-0 sm:flex-1"
           // Client parity with the server's per-value cap, so a long paste is
           // refused at the field instead of at submit.
           maxLength={MAX_ACTION_INPUT_TEXT}
         />
       </div>
-      <div className="space-y-2">
-        <Label htmlFor="chat-repo">Repository</Label>
-        {repos.length === 0 ? (
+      {repos.length === 0 ? (
+        <div className="space-y-2">
+          <Label>Repository</Label>
           <p className="text-xs text-muted-foreground">
             Connect a repository to this team to chat.
           </p>
-        ) : (
-          <Select value={repoId || undefined} onValueChange={onRepoChange}>
-            <SelectTrigger id="chat-repo" className="w-full">
-              <SelectValue placeholder="Select a repository" />
-            </SelectTrigger>
-            <SelectContent>
-              {repos.map((repo) => (
-                <SelectItem key={repo.id} value={repo.id}>
-                  {repo.fullName}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        )}
-      </div>
+        </div>
+      ) : (
+        <GlassGroup>
+          <GlassPickerRow
+            label="Repository"
+            value={repoId || undefined}
+            onValueChange={onRepoChange}
+            placeholder="Select a repository"
+            options={repos.map((repo) => ({
+              value: repo.id,
+              label: repo.fullName,
+            }))}
+          />
+        </GlassGroup>
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/launch-dialog/create-action-dialog.tsx
+++ b/apps/web/src/components/launch-dialog/create-action-dialog.tsx
@@ -45,13 +45,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+import { GlassGroup, GlassPickerRow } from "@/components/ui/glass-rows"
 import { Textarea } from "@/components/ui/textarea"
 
 // The dedicated "New action" dialog (EXP-431): the builtin "Create action"
@@ -69,6 +63,10 @@ import { Textarea } from "@/components/ui/textarea"
 // Radix Select forbids an empty-string item value; the unset optional repo
 // rides this sentinel inside the dialog only.
 const NO_REPO = `none`
+
+// EXP-616: the glass dress for a free-text field — the `dark:` prefix is
+// required to beat the stock input/textarea's own `dark:bg-input/30`.
+const GLASS_FIELD = `border-glass-stroke bg-glass-row shadow-none dark:bg-glass-row`
 
 const AutomationIcon = conceptIcon(`action-automation`)
 const ChevronRightIcon = conceptIcon(`ui-chevron-right`)
@@ -277,7 +275,7 @@ export function CreateActionDialog({
       {/* Fixed panel height from `sm` up (EXP-615): the automation detail
           slides over the form inside ONE frame, so the dialog must not resize
           between the two. Mobile stays the full-screen page. */}
-      <DialogContent className="gap-3 sm:h-[min(85dvh,34rem)] sm:max-h-[85dvh] sm:max-w-2xl">
+      <DialogContent className="gap-3 sm:h-[min(85dvh,36rem)] sm:max-h-[85dvh] sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>New action</DialogTitle>
         </DialogHeader>
@@ -307,6 +305,7 @@ export function CreateActionDialog({
                     value={name}
                     onChange={(e) => setName(e.target.value)}
                     placeholder={nameDef?.placeholder}
+                    className={GLASS_FIELD}
                     maxLength={MAX_ACTION_INPUT_TEXT}
                   />
                 </div>
@@ -319,47 +318,45 @@ export function CreateActionDialog({
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
                   placeholder={descriptionDef?.placeholder}
-                  className="min-h-28"
+                  className={cn(`min-h-28`, GLASS_FIELD)}
                   // Client parity with the server's per-value cap, so a long
                   // paste is refused at the field instead of at submit.
                   maxLength={MAX_ACTION_INPUT_TEXT}
                 />
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="create-action-repo">Repository (optional)</Label>
-                <Select
+              {/* EXP-616: ONE grouped card — the repository picker row, and
+                  the automation row that slides into its detail view. */}
+              <GlassGroup>
+                <GlassPickerRow
+                  label="Repository (optional)"
                   value={repoId || NO_REPO}
                   onValueChange={(value) =>
                     setRepoId(value === NO_REPO ? `` : value)
                   }
+                  placeholder="Select a repository"
+                  options={[
+                    { value: NO_REPO, label: `None` },
+                    ...repos.map((repo) => ({
+                      value: repo.id,
+                      label: repo.fullName,
+                    })),
+                  ]}
+                />
+                <button
+                  type="button"
+                  onClick={openAutomation}
+                  className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors duration-fast hover:bg-glass-active/50"
                 >
-                  <SelectTrigger id="create-action-repo" className="w-full">
-                    <SelectValue placeholder="Select a repository" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value={NO_REPO}>None</SelectItem>
-                    {repos.map((repo) => (
-                      <SelectItem key={repo.id} value={repo.id}>
-                        {repo.fullName}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <button
-                type="button"
-                onClick={openAutomation}
-                className="flex w-full items-center gap-2 rounded-md border border-border px-3 py-2 text-left hover:bg-muted/50"
-              >
-                <AutomationIcon className="size-4 shrink-0 text-muted-foreground" />
-                <span className="min-w-0 flex-1">
-                  <span className="block text-sm">Automation</span>
-                  <span className="block truncate text-xs text-muted-foreground">
-                    {automationSummary}
+                  <AutomationIcon className="size-4 shrink-0 text-muted-foreground" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-sm">Automation</span>
+                    <span className="block truncate text-xs text-foreground/50">
+                      {automationSummary}
+                    </span>
                   </span>
-                </span>
-                <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground" />
-              </button>
+                  <ChevronRightIcon className="size-3.5 shrink-0 text-foreground/50" />
+                </button>
+              </GlassGroup>
               {triggerOverflow && (
                 <p className="text-xs text-destructive">
                   Description plus the automation block exceeds the
@@ -424,7 +421,6 @@ export function CreateActionDialog({
                 teamId={teamId}
               />
               <AutomationDevicePicker
-                id="create-action-automation-device"
                 deviceId={automationDeviceId}
                 devices={automationCandidates}
                 onChange={setAutomationDeviceId}

--- a/apps/web/src/components/launch-dialog/create-action-dialog.tsx
+++ b/apps/web/src/components/launch-dialog/create-action-dialog.tsx
@@ -64,10 +64,6 @@ import { Textarea } from "@/components/ui/textarea"
 // rides this sentinel inside the dialog only.
 const NO_REPO = `none`
 
-// EXP-616: the glass dress for a free-text field — the `dark:` prefix is
-// required to beat the stock input/textarea's own `dark:bg-input/30`.
-const GLASS_FIELD = `border-glass-stroke bg-glass-row shadow-none dark:bg-glass-row`
-
 const AutomationIcon = conceptIcon(`action-automation`)
 const ChevronRightIcon = conceptIcon(`ui-chevron-right`)
 const BackIcon = conceptIcon(`ui-back`)
@@ -272,10 +268,15 @@ export function CreateActionDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      {/* Fixed panel height from `sm` up (EXP-615): the automation detail
-          slides over the form inside ONE frame, so the dialog must not resize
-          between the two. Mobile stays the full-screen page. */}
-      <DialogContent className="gap-3 sm:h-[min(85dvh,36rem)] sm:max-h-[85dvh] sm:max-w-2xl">
+      {/* Fixed panel height (EXP-615): the automation detail slides over the
+          form inside ONE frame, so the dialog must not resize between the two.
+          EXP-616: the height is unprefixed now because the mobile arm is a
+          bottom sheet — both halves are absolutely positioned, so a
+          content-sized sheet would collapse to header + footer. */}
+      <DialogContent
+        mobileSheet
+        className="h-[min(85dvh,36rem)] gap-3 sm:max-h-[85dvh] sm:max-w-2xl"
+      >
         <DialogHeader>
           <DialogTitle>New action</DialogTitle>
         </DialogHeader>
@@ -305,7 +306,6 @@ export function CreateActionDialog({
                     value={name}
                     onChange={(e) => setName(e.target.value)}
                     placeholder={nameDef?.placeholder}
-                    className={GLASS_FIELD}
                     maxLength={MAX_ACTION_INPUT_TEXT}
                   />
                 </div>
@@ -318,7 +318,7 @@ export function CreateActionDialog({
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
                   placeholder={descriptionDef?.placeholder}
-                  className={cn(`min-h-28`, GLASS_FIELD)}
+                  className="min-h-28"
                   // Client parity with the server's per-value cap, so a long
                   // paste is refused at the field instead of at submit.
                   maxLength={MAX_ACTION_INPUT_TEXT}

--- a/apps/web/src/components/launch-dialog/create-action-dialog.tsx
+++ b/apps/web/src/components/launch-dialog/create-action-dialog.tsx
@@ -270,12 +270,13 @@ export function CreateActionDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* Fixed panel height (EXP-615): the automation detail slides over the
           form inside ONE frame, so the dialog must not resize between the two.
-          EXP-616: the height is unprefixed now because the mobile arm is a
-          bottom sheet — both halves are absolutely positioned, so a
-          content-sized sheet would collapse to header + footer. */}
+          Both halves are absolutely positioned, so the frame needs a definite
+          height on every breakpoint — below `sm` the mobile sheet's own fixed
+          94dvh detent supplies it (EXP-616), which is why this one is
+          sm:-prefixed. */}
       <DialogContent
         mobileSheet
-        className="h-[min(85dvh,36rem)] gap-3 sm:max-h-[85dvh] sm:max-w-2xl"
+        className="gap-3 sm:h-[min(85dvh,36rem)] sm:max-h-[85dvh] sm:max-w-2xl"
       >
         <DialogHeader>
           <DialogTitle>New action</DialogTitle>
@@ -292,33 +293,43 @@ export function CreateActionDialog({
             )}
           >
             <div className="flex shrink-0 flex-col gap-3 sm:min-h-0 sm:shrink sm:overflow-y-auto">
-              <div className="space-y-2">
-                <Label htmlFor="create-action-name">Name (optional)</Label>
-                <div className="flex items-center gap-2">
-                  <IconPicker
-                    id="create-action-icon"
-                    value={icon as BoardIcon | ``}
-                    onChange={setIcon}
-                    allowsNone
-                  />
-                  <Input
-                    id="create-action-name"
-                    value={name}
-                    onChange={(e) => setName(e.target.value)}
-                    placeholder={nameDef?.placeholder}
-                    maxLength={MAX_ACTION_INPUT_TEXT}
-                  />
-                </div>
+              {/* EXP-616: the icon + name row LEADS the column, uncaptioned —
+                  the placeholder ("Name (optional)") already says what it is,
+                  so the visible label only cost the column its top edge and
+                  pushed it out of line with the right half's "Agent" label.
+                  The a11y name rides `aria-label` instead. */}
+              <div className="flex items-center gap-2">
+                <IconPicker
+                  id="create-action-icon"
+                  value={icon as BoardIcon | ``}
+                  onChange={setIcon}
+                  allowsNone
+                />
+                <Input
+                  id="create-action-name"
+                  aria-label={nameDef?.label}
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder={nameDef?.placeholder}
+                  maxLength={MAX_ACTION_INPUT_TEXT}
+                />
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="create-action-description">Description</Label>
+              {/* The description is its OWN glass card — caption-sized label,
+                  borderless field (the Chat tab's Prompt, EXP-616). */}
+              <div className="flex flex-col gap-1 rounded-lg bg-glass-row p-3">
+                <Label
+                  htmlFor="create-action-description"
+                  className="text-xs text-foreground/50"
+                >
+                  Description
+                </Label>
                 <Textarea
                   id="create-action-description"
                   autoFocus
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
                   placeholder={descriptionDef?.placeholder}
-                  className="min-h-28"
+                  className="min-h-28 border-0 bg-transparent px-0 shadow-none focus-visible:ring-0"
                   // Client parity with the server's per-value cap, so a long
                   // paste is refused at the field instead of at submit.
                   maxLength={MAX_ACTION_INPUT_TEXT}

--- a/apps/web/src/components/launch-dialog/issues-pane.tsx
+++ b/apps/web/src/components/launch-dialog/issues-pane.tsx
@@ -50,9 +50,9 @@ export function IssuesPane({
           value={search}
           onChange={(e) => onSearchChange(e.target.value)}
           placeholder="Search issues…"
-          // EXP-616: the glass field dress — the `dark:` prefix is required to
-          // beat the stock input's own `dark:bg-input/30`.
-          className="h-9 rounded-md border-glass-stroke bg-glass-row pl-8 shadow-none dark:bg-glass-row"
+          // The glass dress is the stock Input's own (EXP-616); only the
+          // leading room for the search glyph is local.
+          className="h-9 rounded-md pl-8"
         />
       </div>
       <div className="max-h-44 overflow-y-auto rounded-lg border-0 bg-glass-row sm:max-h-none sm:min-h-32 sm:flex-1">

--- a/apps/web/src/components/launch-dialog/issues-pane.tsx
+++ b/apps/web/src/components/launch-dialog/issues-pane.tsx
@@ -50,10 +50,12 @@ export function IssuesPane({
           value={search}
           onChange={(e) => onSearchChange(e.target.value)}
           placeholder="Search issues…"
-          className="h-9 pl-8"
+          // EXP-616: the glass field dress — the `dark:` prefix is required to
+          // beat the stock input's own `dark:bg-input/30`.
+          className="h-9 rounded-md border-glass-stroke bg-glass-row pl-8 shadow-none dark:bg-glass-row"
         />
       </div>
-      <div className="max-h-44 overflow-y-auto rounded-md border border-border sm:max-h-none sm:min-h-32 sm:flex-1">
+      <div className="max-h-44 overflow-y-auto rounded-lg border-0 bg-glass-row sm:max-h-none sm:min-h-32 sm:flex-1">
         {rows.length === 0 ? (
           <div className="px-3 py-6 text-center text-xs text-muted-foreground">
             {search.trim()
@@ -75,7 +77,7 @@ export function IssuesPane({
                     onToggle(issue.id)
                   }
                 }}
-                className="flex cursor-pointer items-center gap-2 border-b border-border/30 px-3 py-2 last:border-b-0 hover:bg-muted/50"
+                className="flex cursor-pointer items-center gap-2 border-b border-glass-stroke px-3 py-2 last:border-b-0 hover:bg-glass-active/50"
               >
                 <Checkbox
                   checked={checked}

--- a/apps/web/src/components/launch-dialog/launch-dialog.tsx
+++ b/apps/web/src/components/launch-dialog/launch-dialog.tsx
@@ -506,16 +506,17 @@ export function LaunchDialog({
       {/* The header/tabs/footer stay anchored (the ui/dialog base is a flex
           column) while only the BODY takes the height budget — it is the
           flex-1 min-h-0 row. On mobile the dialog is a bottom sheet
-          (EXP-616 — `mobileSheet` on the ui/dialog base: content height up to
-          92dvh) and the body stacks vertically,
+          (EXP-616 — `mobileSheet` on the ui/dialog base: a fixed 94dvh
+          detent) and the body stacks vertically,
           scrolling as one region; from `sm` up the body splits into two
           columns — issue/action picker left, launch options right — where
           ONLY the picker list scrolls, so the dialog never shows nested
           scrollbars.
           EXP-615: from `sm` up the panel takes a FIXED height (the Actions
           tab's natural one) so switching Issues/Actions/Chat never resizes the
-          dialog under the pointer; the mobile sheet keeps following its
-          content (every pane is `shrink-0` with its own capped list there). */}
+          dialog under the pointer; the mobile sheet takes the base detent
+          (every pane is `shrink-0` with its own capped list there, so the body
+          scrolls as one region anchored to the top). */}
       <DialogContent
         mobileSheet
         className="gap-3 sm:h-[min(85dvh,36rem)] sm:max-h-[85dvh] sm:max-w-3xl"

--- a/apps/web/src/components/launch-dialog/launch-dialog.tsx
+++ b/apps/web/src/components/launch-dialog/launch-dialog.tsx
@@ -514,7 +514,7 @@ export function LaunchDialog({
           EXP-615: from `sm` up the panel takes a FIXED height (the Actions
           tab's natural one) so switching Issues/Actions/Chat never resizes the
           dialog under the pointer; mobile keeps the full-screen page. */}
-      <DialogContent className="gap-3 sm:h-[min(85dvh,34rem)] sm:max-h-[85dvh] sm:max-w-3xl">
+      <DialogContent className="gap-3 sm:h-[min(85dvh,36rem)] sm:max-h-[85dvh] sm:max-w-3xl">
         <DialogHeader>
           <DialogTitle>
             {tab === `actions`

--- a/apps/web/src/components/launch-dialog/launch-dialog.tsx
+++ b/apps/web/src/components/launch-dialog/launch-dialog.tsx
@@ -505,16 +505,21 @@ export function LaunchDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* The header/tabs/footer stay anchored (the ui/dialog base is a flex
           column) while only the BODY takes the height budget — it is the
-          flex-1 min-h-0 row. On mobile the dialog is a full-screen page
-          (EXP-255 — the ui/dialog base) and the body stacks vertically,
+          flex-1 min-h-0 row. On mobile the dialog is a bottom sheet
+          (EXP-616 — `mobileSheet` on the ui/dialog base: content height up to
+          92dvh) and the body stacks vertically,
           scrolling as one region; from `sm` up the body splits into two
           columns — issue/action picker left, launch options right — where
           ONLY the picker list scrolls, so the dialog never shows nested
           scrollbars.
           EXP-615: from `sm` up the panel takes a FIXED height (the Actions
           tab's natural one) so switching Issues/Actions/Chat never resizes the
-          dialog under the pointer; mobile keeps the full-screen page. */}
-      <DialogContent className="gap-3 sm:h-[min(85dvh,36rem)] sm:max-h-[85dvh] sm:max-w-3xl">
+          dialog under the pointer; the mobile sheet keeps following its
+          content (every pane is `shrink-0` with its own capped list there). */}
+      <DialogContent
+        mobileSheet
+        className="gap-3 sm:h-[min(85dvh,36rem)] sm:max-h-[85dvh] sm:max-w-3xl"
+      >
         <DialogHeader>
           <DialogTitle>
             {tab === `actions`

--- a/apps/web/src/components/launch-dialog/launch-options-pane.tsx
+++ b/apps/web/src/components/launch-dialog/launch-options-pane.tsx
@@ -32,10 +32,12 @@ import type { SteerDevice } from "@/lib/steer-devices"
 // unattended run never parks on plan mode.
 // EXP-616 dresses the cluster in the iOS grouped-glass vocabulary: the agent
 // capsule stays uncarded and flush, everything else is a grouped card of
-// label-leading picker/toggle ROWS (`components/ui/glass-rows`). Section order
-// mirrors the iOS `LaunchOptionsSection` exactly — device card, capsule,
-// model/effort card, toggles card — so the caller hands its device picker over
-// as `deviceRow` and this renders the card around it.
+// label-leading picker/toggle ROWS (`components/ui/glass-rows`). The "Agent"
+// label LEADS the column so it sits on the same baseline as the left half's
+// section label ("Issues"/the name field); the machine, the model and the
+// effort then share ONE card (device first), and the run-time toggles follow
+// as their own — so the caller hands its device picker over as `deviceRow` and
+// this renders it as that card's first row.
 
 export const AGENT_LABELS: Record<string, string> = {
   claude: `Claude Code`,
@@ -107,10 +109,10 @@ type AgentOptionsFieldsProps = {
   idPrefix: string
   /**
    * EXP-616: the caller's device picker row (a `GlassPickerRow`), rendered as
-   * its OWN card above the agent capsule — the iOS sheet's device section.
-   * Absent where there is nothing to pick: the device-settings defaults editor
-   * edits one machine's own defaults, and a one-machine launch has no choice
-   * to offer, so neither paints a device card.
+   * the FIRST row of the model/effort card. Absent where there is nothing to
+   * pick: the device-settings defaults editor edits one machine's own
+   * defaults, and a one-machine launch has no choice to offer, so neither
+   * paints a device row at all.
    */
   deviceRow?: React.ReactNode
   /** `` in the automation variant = device default. */
@@ -172,9 +174,6 @@ export function AgentOptionsFields(props: AgentOptionsFieldsProps) {
   ]
   return (
     <>
-      {/* The machine gets its own card, ahead of the agent capsule — the iOS
-          sheet's section order (device → capsule → model/effort → toggles). */}
-      {deviceRow && <GlassGroup>{deviceRow}</GlassGroup>}
       {availableAgents.length > 1 && (
         <div className="space-y-2">
           <Label>Agent</Label>
@@ -193,8 +192,10 @@ export function AgentOptionsFields(props: AgentOptionsFieldsProps) {
           </Tabs>
         </div>
       )}
-      {/* What the machine runs with — the iOS sheet's Model/Effort card. */}
+      {/* Where and what the agent runs with — ONE card: the machine leads,
+          model and effort follow. */}
       <GlassGroup>
+        {deviceRow}
         <GlassPickerRow
           label="Model"
           value={model === `` ? modelSentinel : model}

--- a/apps/web/src/components/launch-dialog/launch-options-pane.tsx
+++ b/apps/web/src/components/launch-dialog/launch-options-pane.tsx
@@ -1,14 +1,12 @@
 import { MonitorOff } from "lucide-react"
 import { conceptIcon } from "@/lib/icons.generated"
-import { Checkbox } from "@/components/ui/checkbox"
 import { Label } from "@/components/ui/label"
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+  GlassGroup,
+  GlassPickerRow,
+  GlassToggleRow,
+  type GlassPickerOption,
+} from "@/components/ui/glass-rows"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { ClaudeIcon, CodexIcon, PiIcon } from "@/components/icons/brand-icons"
 import {
@@ -32,6 +30,12 @@ import type { SteerDevice } from "@/lib/steer-devices"
 // strip and selects (the agent seeds to the bound device's default launch
 // agent; blank model/effort store NULL), minus the run-time toggles — an
 // unattended run never parks on plan mode.
+// EXP-616 dresses the cluster in the iOS grouped-glass vocabulary: the agent
+// capsule stays uncarded and flush, everything else is a grouped card of
+// label-leading picker/toggle ROWS (`components/ui/glass-rows`). Section order
+// mirrors the iOS `LaunchOptionsSection` exactly — device card, capsule,
+// model/effort card, toggles card — so the caller hands its device picker over
+// as `deviceRow` and this renders the card around it.
 
 export const AGENT_LABELS: Record<string, string> = {
   claude: `Claude Code`,
@@ -101,6 +105,14 @@ interface LaunchToggleProps {
 
 type AgentOptionsFieldsProps = {
   idPrefix: string
+  /**
+   * EXP-616: the caller's device picker row (a `GlassPickerRow`), rendered as
+   * its OWN card above the agent capsule — the iOS sheet's device section.
+   * Absent where there is nothing to pick: the device-settings defaults editor
+   * edits one machine's own defaults, and a one-machine launch has no choice
+   * to offer, so neither paints a device card.
+   */
+  deviceRow?: React.ReactNode
   /** `` in the automation variant = device default. */
   agent: string
   availableAgents: string[]
@@ -120,6 +132,7 @@ type AgentOptionsFieldsProps = {
 export function AgentOptionsFields(props: AgentOptionsFieldsProps) {
   const {
     idPrefix,
+    deviceRow,
     agent,
     availableAgents,
     onAgentChange,
@@ -137,8 +150,31 @@ export function AgentOptionsFields(props: AgentOptionsFieldsProps) {
   const modelSentinel = CLI_DEFAULT_MODEL
   const effortSentinel = CLI_DEFAULT_EFFORT
   const sentinelLabel = `CLI default`
+  const modelOptions: GlassPickerOption[] = [
+    ...(automation || agentAllowsBlankModel(agent)
+      ? [{ value: modelSentinel, label: sentinelLabel }]
+      : []),
+    ...(pinned
+      ? agentModelValues(agent).map((value) => ({
+          value,
+          label: modelLabel(value),
+        }))
+      : []),
+  ]
+  const effortOptions: GlassPickerOption[] = [
+    { value: effortSentinel, label: sentinelLabel },
+    ...(pinned
+      ? agentEffortValues(agent).map((value) => ({
+          value,
+          label: effortLabel(value),
+        }))
+      : []),
+  ]
   return (
     <>
+      {/* The machine gets its own card, ahead of the agent capsule — the iOS
+          sheet's section order (device → capsule → model/effort → toggles). */}
+      {deviceRow && <GlassGroup>{deviceRow}</GlassGroup>}
       {availableAgents.length > 1 && (
         <div className="space-y-2">
           <Label>Agent</Label>
@@ -157,68 +193,37 @@ export function AgentOptionsFields(props: AgentOptionsFieldsProps) {
           </Tabs>
         </div>
       )}
-      <div className="grid grid-cols-2 gap-3">
-        <div className="space-y-2">
-          <Label htmlFor={`${idPrefix}-model`}>Model</Label>
-          <Select
-            value={model === `` ? modelSentinel : model}
-            onValueChange={(value) =>
-              onModelChange(value === modelSentinel ? `` : value)
-            }
-            disabled={!pinned}
-          >
-            <SelectTrigger id={`${idPrefix}-model`} className="w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {(automation || agentAllowsBlankModel(agent)) && (
-                <SelectItem value={modelSentinel}>{sentinelLabel}</SelectItem>
-              )}
-              {pinned &&
-                agentModelValues(agent).map((value) => (
-                  <SelectItem key={value} value={value}>
-                    {modelLabel(value)}
-                  </SelectItem>
-                ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor={`${idPrefix}-effort`}>
-            {agent === `pi`
+      {/* What the machine runs with — the iOS sheet's Model/Effort card. */}
+      <GlassGroup>
+        <GlassPickerRow
+          label="Model"
+          value={model === `` ? modelSentinel : model}
+          onValueChange={(value) =>
+            onModelChange(value === modelSentinel ? `` : value)
+          }
+          options={modelOptions}
+          disabled={!pinned}
+        />
+        <GlassPickerRow
+          label={
+            agent === `pi`
               ? `Thinking`
               : agent === `codex`
                 ? `Reasoning`
-                : `Effort`}
-          </Label>
-          <Select
-            value={effortValue === `` ? effortSentinel : effortValue}
-            onValueChange={(value) =>
-              onEffortChange(
-                automation && value === effortSentinel ? `` : value
-              )
-            }
-            disabled={
-              automation
-                ? !pinned
-                : toggles!.ultracode && agentSupportsUltracode(agent)
-            }
-          >
-            <SelectTrigger id={`${idPrefix}-effort`} className="w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={effortSentinel}>{sentinelLabel}</SelectItem>
-              {pinned &&
-                agentEffortValues(agent).map((value) => (
-                  <SelectItem key={value} value={value}>
-                    {effortLabel(value)}
-                  </SelectItem>
-                ))}
-            </SelectContent>
-          </Select>
-        </div>
-      </div>
+                : `Effort`
+          }
+          value={effortValue === `` ? effortSentinel : effortValue}
+          onValueChange={(value) =>
+            onEffortChange(automation && value === effortSentinel ? `` : value)
+          }
+          options={effortOptions}
+          disabled={
+            automation
+              ? !pinned
+              : toggles!.ultracode && agentSupportsUltracode(agent)
+          }
+        />
+      </GlassGroup>
       {toggles && (
         <LaunchToggles {...toggles} idPrefix={idPrefix} agent={agent} />
       )}
@@ -238,75 +243,55 @@ function LaunchToggles({
   onSkipPermissionsChange,
   resumeRow,
 }: LaunchToggleProps & { idPrefix: string; agent: string }) {
+  // EXP-616: the second grouped card — one switch row per capability,
+  // mirroring the iOS sheet's toggles section. The guard stays outside it so
+  // an agent with no applicable capability paints no empty card.
   return (
     <>
       {(resumeRow ||
         agentSupportsUltracode(agent) ||
         (agentSupportsPlanMode(agent) && !planModeHidden) ||
         agentSupportsSkipPermissions(agent)) && (
-        <div className="space-y-2">
+        <GlassGroup>
           {resumeRow && (
-            <div className="space-y-1">
-              <div className="flex items-center gap-2">
-                <Checkbox
-                  id={`${idPrefix}-resume`}
-                  checked={resumeRow.checked}
-                  onCheckedChange={(value) =>
-                    resumeRow.onChange(value === true)
-                  }
-                />
-                <Label htmlFor={`${idPrefix}-resume`} className="font-normal">
-                  Resume previous session
-                </Label>
-              </div>
-              <p className="flex items-center gap-1 pl-6 text-xs text-muted-foreground">
-                <ResumeBranchIcon className="size-3 shrink-0" />A worktree for{` `}
-                {resumeRow.identifier} already exists ({resumeRow.branch}).
-              </p>
-            </div>
+            <GlassToggleRow
+              id={`${idPrefix}-resume`}
+              label="Resume previous session"
+              checked={resumeRow.checked}
+              onCheckedChange={resumeRow.onChange}
+              description={
+                <span className="flex items-center gap-1">
+                  <ResumeBranchIcon className="size-3 shrink-0" />
+                  {`A worktree for ${resumeRow.identifier} already exists (${resumeRow.branch}).`}
+                </span>
+              }
+            />
           )}
           {agentSupportsUltracode(agent) && (
-            <div className="flex items-center gap-2">
-              <Checkbox
-                id={`${idPrefix}-ultracode`}
-                checked={ultracode}
-                onCheckedChange={(value) => onUltracodeChange(value === true)}
-              />
-              <Label htmlFor={`${idPrefix}-ultracode`} className="font-normal">
-                Dynamic workflows (ultracode)
-              </Label>
-            </div>
+            <GlassToggleRow
+              id={`${idPrefix}-ultracode`}
+              label="Dynamic workflows (ultracode)"
+              checked={ultracode}
+              onCheckedChange={onUltracodeChange}
+            />
           )}
           {agentSupportsPlanMode(agent) && !planModeHidden && (
-            <div className="flex items-center gap-2">
-              <Checkbox
-                id={`${idPrefix}-plan-mode`}
-                checked={planMode}
-                onCheckedChange={(value) => onPlanModeChange(value === true)}
-              />
-              <Label htmlFor={`${idPrefix}-plan-mode`} className="font-normal">
-                Plan mode
-              </Label>
-            </div>
+            <GlassToggleRow
+              id={`${idPrefix}-plan-mode`}
+              label="Plan mode"
+              checked={planMode}
+              onCheckedChange={onPlanModeChange}
+            />
           )}
           {agentSupportsSkipPermissions(agent) && (
-            <div className="flex items-center gap-2">
-              <Checkbox
-                id={`${idPrefix}-skip-permissions`}
-                checked={skipPermissions}
-                onCheckedChange={(value) =>
-                  onSkipPermissionsChange(value === true)
-                }
-              />
-              <Label
-                htmlFor={`${idPrefix}-skip-permissions`}
-                className="font-normal"
-              >
-                Skip permissions
-              </Label>
-            </div>
+            <GlassToggleRow
+              id={`${idPrefix}-skip-permissions`}
+              label="Skip permissions"
+              checked={skipPermissions}
+              onCheckedChange={onSkipPermissionsChange}
+            />
           )}
-        </div>
+        </GlassGroup>
       )}
     </>
   )
@@ -370,29 +355,27 @@ export function LaunchOptionsPane({
 
   return (
     <div className="flex shrink-0 flex-col gap-3 sm:min-h-0 sm:shrink sm:overflow-y-auto">
-      {devices.length > 1 && (
-        <div className="space-y-2">
-          {/* EXP-615: "Device", byte-identical on all four clients — a
-              machine here can equally be a headless CLI daemon. */}
-          <Label htmlFor="start-coding-device">Device</Label>
-          <Select value={device?.deviceId ?? ``} onValueChange={onDeviceChange}>
-            <SelectTrigger id="start-coding-device" className="w-full">
-              <SelectValue placeholder="Select a device" />
-            </SelectTrigger>
-            <SelectContent>
-              {devices.map((candidate) => (
-                <SelectItem key={candidate.deviceId} value={candidate.deviceId}>
-                  {candidate.deviceLabel || candidate.deviceId}
-                  {/* EXP-432: teammates' shared servers carry their owner. */}
-                  {candidate.owner ? ` — ${candidate.owner.name}` : ``}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      )}
       <AgentOptionsFields
         idPrefix="start-coding"
+        deviceRow={
+          devices.length > 1 ? (
+            /* EXP-615: "Device", byte-identical on all four clients — a
+               machine here can equally be a headless CLI daemon. */
+            <GlassPickerRow
+              label="Device"
+              value={device?.deviceId ?? ``}
+              onValueChange={onDeviceChange}
+              placeholder="Select a device"
+              options={devices.map((candidate) => ({
+                value: candidate.deviceId,
+                // EXP-432: teammates' shared servers carry their owner.
+                label: `${candidate.deviceLabel || candidate.deviceId}${
+                  candidate.owner ? ` — ${candidate.owner.name}` : ``
+                }`,
+              }))}
+            />
+          ) : null
+        }
         agent={agent}
         availableAgents={availableAgents}
         onAgentChange={onAgentChange}

--- a/apps/web/src/components/my-machines.tsx
+++ b/apps/web/src/components/my-machines.tsx
@@ -20,9 +20,9 @@ import {
   type SteerDevice,
 } from "@/lib/steer-devices"
 import { CopySnippetButton } from "@/components/getting-started/mcp-setup-tabs"
-import { SectionLabel } from "@/components/agent-session-row"
 import { DeviceSettingsDialog } from "@/components/device-settings-dialog"
 import { Button } from "@/components/ui/button"
+import { GlassRow, GlassSectionHeader } from "@/components/ui/glass-rows"
 import {
   Dialog,
   DialogContent,
@@ -164,12 +164,11 @@ export function MyMachines({
   }
 
   return (
-    <div className="mb-4">
-      {/* EXP-449: same full-width band + trailing-button treatment as the
-          Actions section below. */}
-      <SectionLabel
+    <div className="mb-6">
+      {/* EXP-616: the iOS Agents screen's plain-text section header — no
+          count, the trailing control rides along. */}
+      <GlassSectionHeader
         label="My machines"
-        count={mine?.length ?? 0}
         trailing={
           <Button
             variant="outline"
@@ -184,200 +183,68 @@ export function MyMachines({
       />
 
       {mine === null ? (
-        <div className="px-3 py-3 text-sm text-muted-foreground">Loading…</div>
+        <div className="px-1 py-3 text-sm text-muted-foreground">Loading…</div>
       ) : mine.length === 0 ? (
-        <div className="flex items-center gap-2 px-3 py-3 text-xs text-muted-foreground">
+        <div className="flex items-center gap-2 px-1 py-3 text-xs text-muted-foreground">
           <OfflineIcon className="size-3.5 shrink-0" />
           No machines yet. Open the Exponential desktop app, or add a server.
         </div>
       ) : (
-        mine.map((device) => {
-          const online = deviceIsOnline(device)
-          // EXP-409: installed-but-signed-out agents grey the machine out
-          // (online but nothing runnable) or annotate it (a runnable
-          // sibling still covers coding).
-          const unauthed = deviceUnauthedAgentIds(device)
-          const runnable = deviceHasRunnableAgent(device)
-          const signInNeeded = online && !runnable && unauthed.length > 0
-          const KindIcon = device.kind === `server` ? ServerIcon : DesktopIcon
-          const latest =
-            device.kind === `server`
-              ? latestVersions?.cli
-              : latestVersions?.desktop
-          const outdated = deviceUpdateAvailable(device.version, latest)
-          return (
-            <div
-              key={device.deviceId}
-              className={`flex items-center gap-3 border-b border-border/30 px-3 py-2 ${
-                signInNeeded ? `opacity-60` : ``
-              }`}
-            >
-              <KindIcon className="size-4 shrink-0 text-muted-foreground" />
-              {/* FEED-15: the native two-line row — name + version (+ Shared)
-                  on top, live/last-seen state beneath, controls trailing —
-                  so phones never wrap the launcher onto its own line. */}
-              <div className="min-w-0 flex-1">
-                <div className="flex min-w-0 items-baseline gap-1.5">
-                  <span className="min-w-0 truncate text-sm font-medium">
-                    {device.deviceLabel || device.deviceId}
-                  </span>
-                  {device.version && (
-                    <span
-                      className={`shrink-0 text-[10px] ${
-                        outdated
-                          ? `text-amber-500`
-                          : `text-muted-foreground/60`
-                      }`}
-                      title={
-                        outdated ? `Update available: ${latest}` : undefined
-                      }
-                    >
-                      v{device.version}
-                    </span>
-                  )}
-                  {device.sharedTeamId && (
-                    <span
-                      className="shrink-0 rounded-sm border border-border/60 px-1 text-[10px] text-muted-foreground"
-                      title={
-                        device.sharedTeamId === teamId
-                          ? `Shared with this team — teammates can start coding sessions on this machine.`
-                          : `Shared with another team.`
-                      }
-                    >
-                      Shared
-                    </span>
-                  )}
-                </div>
-                <DeviceStatusLine
-                  online={online}
-                  signInNeeded={signInNeeded}
-                  unauthed={unauthed}
-                  lastSeenAt={device.lastSeenAt}
-                />
-              </div>
-              <div className="flex shrink-0 items-center gap-1">
-                {/* EXP-420: only when a newer version really exists (or an
-                    update is already in flight — keep its progress visible). */}
-                {(showDeviceUpdateButton(device, latest) ||
-                  updatingId === device.deviceId) && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className={outdated ? `text-amber-500` : `text-muted-foreground`}
-                    disabled={device.updateRequested || updatingId === device.deviceId}
-                    title={
-                      device.updateRequested && device.updateBlocked
-                        ? `A coding session is running — this machine updates itself once all sessions are closed.`
-                        : `Ask the daemon to self-update (it restarts when idle)`
-                    }
-                    onClick={() => void requestUpdate(device)}
-                  >
-                    {device.updateRequested && device.updateBlocked ? (
-                      // EXP-411: parked behind live sessions — say so instead
-                      // of spinning until the last one closes.
-                      <>
-                        <UpdateIcon />
-                        <span className="max-sm:sr-only">Queued</span>
-                      </>
-                    ) : device.updateRequested ||
-                      updatingId === device.deviceId ? (
-                      <>
-                        <LoaderCircle className="animate-spin" />
-                        <span className="max-sm:sr-only">Updating…</span>
-                      </>
-                    ) : (
-                      <>
-                        <UpdateIcon />
-                        <span className="max-sm:sr-only">Update</span>
-                      </>
-                    )}
-                  </Button>
-                )}
-                <span
-                  title={
-                    signInNeeded
-                      ? `No agent is signed in on this machine — sign in on the machine first (e.g. run \`${unauthed[0]}\` there).`
-                      : undefined
-                  }
-                >
-                  <Button
-                    variant="outline"
-                    size="icon"
-                    disabled={runBusy || !online || signInNeeded}
-                    onClick={() => onStartCoding(device.deviceId)}
-                    aria-label="Start coding"
-                    // The wrapping span explains a sign-in block; its tooltip
-                    // must not be shadowed by this one.
-                    title={signInNeeded ? undefined : `Start coding`}
-                  >
-                    <StartCodingIcon />
-                  </Button>
-                </span>
-                {device.registered && (
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="size-8 text-muted-foreground"
-                        aria-label={`Machine menu for ${device.deviceLabel || device.deviceId}`}
-                      >
-                        <MoreIcon className="size-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      {/* EXP-481: rename, sharing, agent defaults and
-                          worktrees all live in the settings dialog. */}
-                      <DropdownMenuItem
-                        onSelect={() => setSettingsTargetId(device.deviceId)}
-                      >
-                        <EditIcon />
-                        Edit
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        variant="destructive"
-                        onSelect={() => setRemoveTarget(device)}
-                      >
-                        <RemoveIcon />
-                        Remove
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                )}
-              </div>
-            </div>
-          )
-        })
-      )}
-      {/* EXP-432: teammates' server devices shared with this team —
-          read-only rows (owner name shown, no rename/remove/update), but
-          fully startable. */}
-      {teamShared.length > 0 && (
-        <div className="mt-4">
-          <SectionLabel label="Team machines" count={teamShared.length} />
-          {teamShared.map((device) => {
+        <div className="flex flex-col gap-2">
+          {mine.map((device) => {
             const online = deviceIsOnline(device)
+            // EXP-409: installed-but-signed-out agents grey the machine out
+            // (online but nothing runnable) or annotate it (a runnable
+            // sibling still covers coding).
             const unauthed = deviceUnauthedAgentIds(device)
             const runnable = deviceHasRunnableAgent(device)
             const signInNeeded = online && !runnable && unauthed.length > 0
+            const KindIcon = device.kind === `server` ? ServerIcon : DesktopIcon
+            const latest =
+              device.kind === `server`
+                ? latestVersions?.cli
+                : latestVersions?.desktop
+            const outdated = deviceUpdateAvailable(device.version, latest)
             return (
-              <div
+              <GlassRow
                 key={device.deviceId}
-                className={`flex items-center gap-3 border-b border-border/30 px-3 py-2 ${
-                  signInNeeded ? `opacity-60` : ``
-                }`}
+                className={signInNeeded ? `opacity-60` : undefined}
               >
-                <ServerIcon className="size-4 shrink-0 text-muted-foreground" />
+                <KindIcon className="size-4 shrink-0 text-foreground/70" />
+                {/* FEED-15: the native two-line row — name + version (+ Shared)
+                    on top, live/last-seen state beneath, controls trailing —
+                    so phones never wrap the launcher onto its own line. */}
                 <div className="min-w-0 flex-1">
-                  {/* EXP-525: no people names inline — a teammate's shared
-                      row keeps the attribution in its tooltip. */}
-                  <div
-                    className="min-w-0 truncate text-sm font-medium"
-                    title={
-                      device.owner ? `Shared by ${device.owner.name}` : undefined
-                    }
-                  >
-                    {device.deviceLabel || device.deviceId}
+                  <div className="flex min-w-0 items-baseline gap-1.5">
+                    <span className="min-w-0 truncate text-sm font-medium">
+                      {device.deviceLabel || device.deviceId}
+                    </span>
+                    {device.version && (
+                      <span
+                        className={`shrink-0 text-[10px] ${
+                          outdated
+                            ? `text-amber-500`
+                            : `text-muted-foreground/60`
+                        }`}
+                        title={
+                          outdated ? `Update available: ${latest}` : undefined
+                        }
+                      >
+                        v{device.version}
+                      </span>
+                    )}
+                    {device.sharedTeamId && (
+                      <span
+                        className="shrink-0 rounded-sm border border-border/60 px-1 text-[10px] text-muted-foreground"
+                        title={
+                          device.sharedTeamId === teamId
+                            ? `Shared with this team — teammates can start coding sessions on this machine.`
+                            : `Shared with another team.`
+                        }
+                      >
+                        Shared
+                      </span>
+                    )}
                   </div>
                   <DeviceStatusLine
                     online={online}
@@ -387,25 +254,157 @@ export function MyMachines({
                   />
                 </div>
                 <div className="flex shrink-0 items-center gap-1">
-                  <Button
-                    variant="outline"
-                    size="icon"
-                    disabled={runBusy || !online || signInNeeded}
-                    onClick={() => onStartCoding(device.deviceId)}
-                    aria-label="Start coding"
-                    title="Start coding"
+                  {/* EXP-420: only when a newer version really exists (or an
+                      update is already in flight — keep its progress visible). */}
+                  {(showDeviceUpdateButton(device, latest) ||
+                    updatingId === device.deviceId) && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className={outdated ? `text-amber-500` : `text-muted-foreground`}
+                      disabled={device.updateRequested || updatingId === device.deviceId}
+                      title={
+                        device.updateRequested && device.updateBlocked
+                          ? `A coding session is running — this machine updates itself once all sessions are closed.`
+                          : `Ask the daemon to self-update (it restarts when idle)`
+                      }
+                      onClick={() => void requestUpdate(device)}
+                    >
+                      {device.updateRequested && device.updateBlocked ? (
+                        // EXP-411: parked behind live sessions — say so instead
+                        // of spinning until the last one closes.
+                        <>
+                          <UpdateIcon />
+                          <span className="max-sm:sr-only">Queued</span>
+                        </>
+                      ) : device.updateRequested ||
+                        updatingId === device.deviceId ? (
+                        <>
+                          <LoaderCircle className="animate-spin" />
+                          <span className="max-sm:sr-only">Updating…</span>
+                        </>
+                      ) : (
+                        <>
+                          <UpdateIcon />
+                          <span className="max-sm:sr-only">Update</span>
+                        </>
+                      )}
+                    </Button>
+                  )}
+                  <span
+                    title={
+                      signInNeeded
+                        ? `No agent is signed in on this machine — sign in on the machine first (e.g. run \`${unauthed[0]}\` there).`
+                        : undefined
+                    }
                   >
-                    <StartCodingIcon />
-                  </Button>
+                    <Button
+                      variant="glass"
+                      size="icon"
+                      disabled={runBusy || !online || signInNeeded}
+                      onClick={() => onStartCoding(device.deviceId)}
+                      aria-label="Start coding"
+                      // The wrapping span explains a sign-in block; its tooltip
+                      // must not be shadowed by this one.
+                      title={signInNeeded ? undefined : `Start coding`}
+                    >
+                      <StartCodingIcon />
+                    </Button>
+                  </span>
+                  {device.registered && (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="size-8 text-foreground/50"
+                          aria-label={`Machine menu for ${device.deviceLabel || device.deviceId}`}
+                        >
+                          <MoreIcon className="size-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        {/* EXP-481: rename, sharing, agent defaults and
+                            worktrees all live in the settings dialog. */}
+                        <DropdownMenuItem
+                          onSelect={() => setSettingsTargetId(device.deviceId)}
+                        >
+                          <EditIcon />
+                          Edit
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          variant="destructive"
+                          onSelect={() => setRemoveTarget(device)}
+                        >
+                          <RemoveIcon />
+                          Remove
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
                 </div>
-              </div>
+              </GlassRow>
             )
           })}
         </div>
       )}
+      {/* EXP-432: teammates' server devices shared with this team —
+          read-only rows (owner name shown, no rename/remove/update), but
+          fully startable. */}
+      {teamShared.length > 0 && (
+        <div className="mt-6">
+          <GlassSectionHeader label="Team machines" />
+          <div className="flex flex-col gap-2">
+            {teamShared.map((device) => {
+              const online = deviceIsOnline(device)
+              const unauthed = deviceUnauthedAgentIds(device)
+              const runnable = deviceHasRunnableAgent(device)
+              const signInNeeded = online && !runnable && unauthed.length > 0
+              return (
+                <GlassRow
+                  key={device.deviceId}
+                  className={signInNeeded ? `opacity-60` : undefined}
+                >
+                  <ServerIcon className="size-4 shrink-0 text-foreground/70" />
+                  <div className="min-w-0 flex-1">
+                    {/* EXP-525: no people names inline — a teammate's shared
+                        row keeps the attribution in its tooltip. */}
+                    <div
+                      className="min-w-0 truncate text-sm font-medium"
+                      title={
+                        device.owner ? `Shared by ${device.owner.name}` : undefined
+                      }
+                    >
+                      {device.deviceLabel || device.deviceId}
+                    </div>
+                    <DeviceStatusLine
+                      online={online}
+                      signInNeeded={signInNeeded}
+                      unauthed={unauthed}
+                      lastSeenAt={device.lastSeenAt}
+                    />
+                  </div>
+                  <div className="flex shrink-0 items-center gap-1">
+                    <Button
+                      variant="glass"
+                      size="icon"
+                      disabled={runBusy || !online || signInNeeded}
+                      onClick={() => onStartCoding(device.deviceId)}
+                      aria-label="Start coding"
+                      title="Start coding"
+                    >
+                      <StartCodingIcon />
+                    </Button>
+                  </div>
+                </GlassRow>
+              )
+            })}
+          </div>
+        </div>
+      )}
 
       {sentTo && (
-        <div className="flex items-center gap-1.5 px-3 py-2 text-xs text-muted-foreground">
+        <div className="flex items-center gap-1.5 px-1 py-2 text-xs text-muted-foreground">
           <LoaderCircle className="size-3 animate-spin" />
           Start sent to {sentTo}. Waiting for the machine…
         </div>

--- a/apps/web/src/components/team-actions-panel.tsx
+++ b/apps/web/src/components/team-actions-panel.tsx
@@ -15,7 +15,6 @@ import {
 import { Github, LoaderCircle, Ellipsis, Pencil, Trash2 } from "lucide-react"
 import { conceptIcon } from "@/lib/icons.generated"
 import { trpc } from "@/lib/trpc-client"
-import { SectionLabel } from "@/components/agent-session-row"
 import { useSteerConfig } from "@/components/agent-session"
 import {
   ActionEditorDialog,
@@ -45,6 +44,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { GlassRow, GlassSectionHeader } from "@/components/ui/glass-rows"
 import {
   Tabs,
   TabsContent,
@@ -146,7 +146,7 @@ function ActionCard({
 }) {
   const CardIcon = getActionIcon(action)
   return (
-    <div className="flex flex-col gap-2 rounded-lg border border-border p-3">
+    <div className="flex flex-col gap-2 rounded-lg border border-glass-stroke bg-glass-row p-3">
       <div className="flex min-w-0 items-center gap-2">
         <CardIcon className="size-4 shrink-0 text-muted-foreground" />
         <span className="min-w-0 flex-1 truncate text-sm font-medium">
@@ -177,7 +177,7 @@ function ActionCard({
       {canRun && (
         <div className="mt-auto pt-1">
           <Button
-            variant="outline"
+            variant="glass"
             size="icon"
             disabled={runBusy}
             onClick={onRun}
@@ -216,8 +216,8 @@ function ActionRow({
 }) {
   const RowIcon = getActionIcon(action)
   return (
-    <div className="flex items-center gap-3 border-b border-border/30 px-3 py-2">
-      <RowIcon className="size-4 shrink-0 text-muted-foreground" />
+    <GlassRow>
+      <RowIcon className="size-4 shrink-0 text-foreground/70" />
       <div className="min-w-0 flex-1">
         <div className="flex min-w-0 items-center gap-1.5 text-sm">
           <span className="truncate font-medium">{action.name}</span>
@@ -250,7 +250,7 @@ function ActionRow({
       </div>
       {canRun && (
         <Button
-          variant="outline"
+          variant="glass"
           size="icon"
           disabled={runBusy}
           onClick={onRun}
@@ -263,7 +263,7 @@ function ActionRow({
       {isOwner && !action.builtin && (
         <ActionMenu action={action} onEdit={onEdit} onDelete={onDelete} />
       )}
-    </div>
+    </GlassRow>
   )
 }
 
@@ -283,8 +283,8 @@ function NoCustomActionsNudge({
       onClick={onClick}
       className={
         mobile
-          ? `flex w-full items-center gap-2 border-b border-border/30 px-3 py-2 text-left text-sm text-muted-foreground hover:bg-muted/50`
-          : `flex flex-col items-start gap-1 rounded-lg border border-dashed border-border p-3 text-left text-sm text-muted-foreground hover:bg-muted/50`
+          ? `flex w-full flex-col items-start gap-1 px-1 py-3 text-left text-sm text-muted-foreground hover:text-foreground`
+          : `flex flex-col items-start gap-1 rounded-lg border border-dashed border-glass-stroke-strong p-3 text-left text-sm text-muted-foreground hover:bg-muted/50`
       }
     >
       <span className="flex items-center gap-2">
@@ -316,7 +316,7 @@ function SuggestionCard({
   const CardIcon =
     BOARD_ICON_COMPONENTS[suggestion.icon as BoardIcon] ?? ActionSuggestionIcon
   return (
-    <div className="flex flex-col gap-2 rounded-lg border border-border p-3">
+    <div className="flex flex-col gap-2 rounded-lg border border-glass-stroke bg-glass-row p-3">
       <div className="flex min-w-0 items-center gap-2">
         <CardIcon className="size-4 shrink-0 text-muted-foreground" />
         <span className="min-w-0 flex-1 truncate text-sm font-medium">
@@ -501,7 +501,7 @@ export function TeamActionsPanel({ team }: { team: Team }) {
         </TabsList>
 
         <TabsContent value="actions">
-          <SectionLabel
+          <GlassSectionHeader
             label="Actions"
             count={sortedActions?.length ?? 0}
             trailing={
@@ -520,11 +520,11 @@ export function TeamActionsPanel({ team }: { team: Team }) {
             }
           />
           {sortedActions === null ? (
-            <div className="px-3 py-3 text-sm text-muted-foreground">
+            <div className="px-1 py-3 text-sm text-muted-foreground">
               Loading…
             </div>
           ) : isMobile ? (
-            <>
+            <div className="flex flex-col gap-2">
               {sortedActions.map((action) => (
                 <ActionRow key={action.id} {...actionItemProps(action)} />
               ))}
@@ -536,7 +536,7 @@ export function TeamActionsPanel({ team }: { team: Team }) {
                     onClick={() => setCreateActionOpen(true)}
                   />
                 )}
-            </>
+            </div>
           ) : (
             <div className="grid gap-3 pt-1 sm:grid-cols-2 xl:grid-cols-3">
               {sortedActions.map((action) => (

--- a/apps/web/src/components/team/boards-section.tsx
+++ b/apps/web/src/components/team/boards-section.tsx
@@ -12,6 +12,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import { GlassGroup } from "@/components/ui/glass-rows"
 import {
   Dialog,
   DialogContent,
@@ -121,11 +122,11 @@ export function TeamBoardsSection({
         </CardHeader>
         <CardContent>
           {boards.length === 0 ? (
-            <div className="rounded-md border px-3 py-2 text-sm text-muted-foreground">
+            <div className="rounded-md border border-glass-stroke bg-glass-row px-3 py-2 text-sm text-muted-foreground">
               No boards in this team yet.
             </div>
           ) : (
-            <div className="divide-y rounded-md border">
+            <GlassGroup>
               {boards.map((board) => {
                 const repo = board.repositoryId
                   ? repoMap.get(board.repositoryId)
@@ -134,7 +135,7 @@ export function TeamBoardsSection({
                 return (
                   <div
                     key={board.id}
-                    className="flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors hover:bg-accent/40"
+                    className="flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors duration-fast hover:bg-glass-active/50"
                     onClick={() => setEditTargetId(board.id)}
                   >
                     <TypeIcon
@@ -207,7 +208,7 @@ export function TeamBoardsSection({
                   </div>
                 )
               })}
-            </div>
+            </GlassGroup>
           )}
         </CardContent>
       </Card>
@@ -383,7 +384,7 @@ function ArchivedBoardsCard({
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <div className="divide-y rounded-md border">
+        <GlassGroup>
           {archived.map((board) => {
             const TypeIcon = getBoardIcon(board)
             return (
@@ -419,7 +420,7 @@ function ArchivedBoardsCard({
               </div>
             )
           })}
-        </div>
+        </GlassGroup>
       </CardContent>
     </Card>
   )
@@ -496,7 +497,7 @@ function PendingDeletionCard({
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <div className="divide-y rounded-md border">
+        <GlassGroup>
           {trashed.map((board) => {
             const TypeIcon = getBoardIcon(board)
             return (
@@ -532,7 +533,7 @@ function PendingDeletionCard({
               </div>
             )
           })}
-        </div>
+        </GlassGroup>
       </CardContent>
     </Card>
   )

--- a/apps/web/src/components/team/general-section.tsx
+++ b/apps/web/src/components/team/general-section.tsx
@@ -48,12 +48,15 @@ export function TeamGeneralSection({ team }: { team: Team }) {
         <CardDescription>Team name</CardDescription>
       </CardHeader>
       <CardContent className="space-y-5">
-        <div className="space-y-2">
-          <Label htmlFor="team-name">Name</Label>
+        <div className="rounded-lg bg-glass-row p-3">
+          <Label htmlFor="team-name" className="text-xs text-foreground/50">
+            Name
+          </Label>
           <Input
             id="team-name"
             value={name}
             onChange={(e) => setName(e.target.value)}
+            className="border-0 bg-transparent px-0 shadow-none focus-visible:ring-0 dark:bg-transparent"
           />
         </div>
 

--- a/apps/web/src/components/team/general-section.tsx
+++ b/apps/web/src/components/team/general-section.tsx
@@ -56,7 +56,7 @@ export function TeamGeneralSection({ team }: { team: Team }) {
             id="team-name"
             value={name}
             onChange={(e) => setName(e.target.value)}
-            className="border-0 bg-transparent px-0 shadow-none focus-visible:ring-0 dark:bg-transparent"
+            className="border-0 bg-transparent px-0 shadow-none focus-visible:ring-0"
           />
         </div>
 

--- a/apps/web/src/components/team/labels-section.tsx
+++ b/apps/web/src/components/team/labels-section.tsx
@@ -92,7 +92,7 @@ function LabelRow({
   }
 
   return (
-    <div className="rounded-md border px-3 py-2">
+    <div className="rounded-md border border-glass-stroke bg-glass-row px-3 py-2">
       <div className="flex items-center gap-3">
         <Popover>
           <PopoverTrigger asChild>
@@ -254,7 +254,7 @@ export function TeamLabelsSection({ teamId }: { teamId: string }) {
         </div>
 
         {creating ? (
-          <div className="mt-3 space-y-3 rounded-md border p-3">
+          <div className="mt-3 space-y-3 rounded-md border border-glass-stroke bg-glass-row p-3">
             <Input
               value={newName}
               onChange={(e) => {

--- a/apps/web/src/components/team/members-section.tsx
+++ b/apps/web/src/components/team/members-section.tsx
@@ -126,7 +126,7 @@ export function TeamMembersSection({
             return (
               <div
                 key={member.id}
-                className="flex items-center justify-between gap-2 rounded-md border px-3 py-2"
+                className="flex items-center justify-between gap-2 rounded-md border border-glass-stroke bg-glass-row px-3 py-2"
               >
                 <div className="flex min-w-0 items-center gap-3">
                   <Avatar className="h-8 w-8 shrink-0">
@@ -458,7 +458,7 @@ function InviteControls({ teamId }: { teamId: string }) {
             {invites.map((invite) => (
               <div
                 key={invite.id}
-                className="flex items-center justify-between rounded-md border px-3 py-2 text-sm"
+                className="flex items-center justify-between rounded-md border border-glass-stroke bg-glass-row px-3 py-2 text-sm"
               >
                 <div className="flex min-w-0 items-center gap-2">
                   <Badge variant="secondary">{invite.role}</Badge>

--- a/apps/web/src/components/team/repositories-section.tsx
+++ b/apps/web/src/components/team/repositories-section.tsx
@@ -34,6 +34,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import { GlassGroup } from "@/components/ui/glass-rows"
 import {
   Command,
   CommandEmpty,
@@ -306,11 +307,11 @@ export function TeamRepositoriesSection({
           )}
 
           {count === 0 ? (
-            <div className="rounded-md border px-3 py-2 text-sm text-muted-foreground">
+            <div className="rounded-md border border-glass-stroke bg-glass-row px-3 py-2 text-sm text-muted-foreground">
               No repositories connected yet.
             </div>
           ) : (
-            <div className="divide-y rounded-md border">
+            <GlassGroup>
               {repos!.map((repo) => (
                 <RepoRow
                   key={repo.id}
@@ -334,7 +335,7 @@ export function TeamRepositoriesSection({
                   }
                 />
               ))}
-            </div>
+            </GlassGroup>
           )}
         </CardContent>
       </Card>

--- a/apps/web/src/components/team/statuses-section.tsx
+++ b/apps/web/src/components/team/statuses-section.tsx
@@ -34,6 +34,7 @@ import { hexWithAlpha } from "@/lib/status-icons"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { GlassGroup } from "@/components/ui/glass-rows"
 import {
   Dialog,
   DialogBody,
@@ -199,7 +200,7 @@ function StatusRow({
   }
 
   return (
-    <div className="rounded-md border px-3 py-2">
+    <div className="rounded-md border border-glass-stroke bg-glass-row px-3 py-2">
       <div className="flex items-center gap-3">
         {isBuiltin ? (
           <StatusTile option={option} />
@@ -520,7 +521,7 @@ function CreateStatusForm({
   }
 
   return (
-    <div className="mt-2 space-y-3 rounded-md border p-3">
+    <div className="mt-2 space-y-3 rounded-md border border-glass-stroke bg-glass-row p-3">
       <Input
         value={name}
         onChange={(e) => {
@@ -646,67 +647,69 @@ function PrAutomationCard({
         <CardTitle className="text-base">PR automation</CardTitle>
       </CardHeader>
       <CardContent className="space-y-3">
-        {PR_AUTOMATION_ROWS.map(({ event, label, defaultKey }) => {
-          const statusId =
-            event === `pr_opened`
-              ? team.prOpenedStatusId
-              : team.prMergedStatusId
-          const automation =
-            event === `pr_opened`
-              ? team.prOpenedAutomation
-              : team.prMergedAutomation
-          const defaultId =
-            pickable.find((option) => option.builtinKey === defaultKey)?.id ??
-            `none`
-          const value =
-            automation === false
-              ? `none`
-              : statusId && pickable.some((option) => option.id === statusId)
-                ? statusId
-                : defaultId
+        <GlassGroup>
+          {PR_AUTOMATION_ROWS.map(({ event, label, defaultKey }) => {
+            const statusId =
+              event === `pr_opened`
+                ? team.prOpenedStatusId
+                : team.prMergedStatusId
+            const automation =
+              event === `pr_opened`
+                ? team.prOpenedAutomation
+                : team.prMergedAutomation
+            const defaultId =
+              pickable.find((option) => option.builtinKey === defaultKey)?.id ??
+              `none`
+            const value =
+              automation === false
+                ? `none`
+                : statusId && pickable.some((option) => option.id === statusId)
+                  ? statusId
+                  : defaultId
 
-          return (
-            <div
-              key={event}
-              className="flex items-center justify-between gap-3"
-            >
-              <span className="min-w-0 text-sm">{label}, move issues to</span>
-              <OptionDropdownMenu
-                value={value}
-                fallbackValue={defaultId}
-                options={menuOptions}
-                mobileTitle={label}
-                align="end"
-                onSelect={(picked) => void persist(event, picked, value)}
-                renderTrigger={(selected) => {
-                  const Icon = selected.icon
-                  return (
-                    // Fixed width so both rows' triggers line up (EXP-328) —
-                    // the label ellipsizes instead of stretching the button.
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="w-44 shrink-0 justify-start"
-                    >
-                      <Icon
-                        className={`h-4 w-4 ${selected.color}`}
-                        style={
-                          selected.colorHex
-                            ? { color: selected.colorHex }
-                            : undefined
-                        }
-                      />
-                      <span className="flex-1 truncate text-left">
-                        {selected.label}
-                      </span>
-                      <ChevronDown className="h-3 w-3 text-muted-foreground" />
-                    </Button>
-                  )
-                }}
-              />
-            </div>
-          )
-        })}
+            return (
+              <div
+                key={event}
+                className="flex items-center justify-between gap-3 px-4 py-3"
+              >
+                <span className="min-w-0 text-sm">{label}, move issues to</span>
+                <OptionDropdownMenu
+                  value={value}
+                  fallbackValue={defaultId}
+                  options={menuOptions}
+                  mobileTitle={label}
+                  align="end"
+                  onSelect={(picked) => void persist(event, picked, value)}
+                  renderTrigger={(selected) => {
+                    const Icon = selected.icon
+                    return (
+                      // Fixed width so both rows' triggers line up (EXP-328) —
+                      // the label ellipsizes instead of stretching the button.
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="w-44 shrink-0 justify-start"
+                      >
+                        <Icon
+                          className={`h-4 w-4 ${selected.color}`}
+                          style={
+                            selected.colorHex
+                              ? { color: selected.colorHex }
+                              : undefined
+                          }
+                        />
+                        <span className="flex-1 truncate text-left">
+                          {selected.label}
+                        </span>
+                        <ChevronDown className="h-3 w-3 text-muted-foreground" />
+                      </Button>
+                    )
+                  }}
+                />
+              </div>
+            )
+          })}
+        </GlassGroup>
         {error && <p className="text-xs text-destructive">{error}</p>}
       </CardContent>
     </Card>

--- a/apps/web/src/components/team/storage-section.tsx
+++ b/apps/web/src/components/team/storage-section.tsx
@@ -219,7 +219,7 @@ export function TeamStorageSection({
           ) : (
             // IDE-parity flex rows (EXP-316) — the old fixed table overflowed
             // the settings column and clipped the status + delete controls.
-            <ul className="flex flex-col gap-1">
+            <ul className="flex flex-col gap-2">
               {rows.map((row) => {
                 const Icon = getAttachmentIcon(row.contentType)
                 const issue = issuesById.get(row.issueId)
@@ -233,7 +233,7 @@ export function TeamStorageSection({
                 return (
                   <li
                     key={row.id}
-                    className="flex min-w-0 items-center gap-2 rounded-md border px-2 py-1.5"
+                    className="flex min-w-0 items-center gap-2 rounded-md border border-glass-stroke bg-glass-row px-2 py-1.5"
                   >
                     <Icon className="size-4 shrink-0 text-muted-foreground" />
                     {row.isImage ? (

--- a/apps/web/src/components/team/widget-section.tsx
+++ b/apps/web/src/components/team/widget-section.tsx
@@ -187,7 +187,7 @@ export function TeamWidgetSection({ team }: { team: Team }) {
 
           <div className="space-y-2">
             {loading ? (
-              <div className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm text-muted-foreground">
+              <div className="flex items-center gap-2 rounded-md border border-glass-stroke bg-glass-row px-3 py-2 text-sm text-muted-foreground">
                 <LoaderCircle className="h-4 w-4 animate-spin" />
                 Loading widgets
               </div>
@@ -196,14 +196,14 @@ export function TeamWidgetSection({ team }: { team: Team }) {
                 {error}
               </div>
             ) : widgets.length === 0 ? (
-              <div className="rounded-md border px-3 py-2 text-sm text-muted-foreground">
+              <div className="rounded-md border border-glass-stroke bg-glass-row px-3 py-2 text-sm text-muted-foreground">
                 No widgets yet. Create one to get an embed snippet.
               </div>
             ) : (
               widgets.map((widget) => (
                 <div
                   key={widget.id}
-                  className="flex flex-col gap-3 overflow-hidden rounded-md border px-3 py-3 sm:flex-row sm:items-center sm:justify-between"
+                  className="flex flex-col gap-3 overflow-hidden rounded-md border border-glass-stroke bg-glass-row px-3 py-3 sm:flex-row sm:items-center sm:justify-between"
                 >
                   <div className="min-w-0 flex-1">
                     <div className="flex flex-wrap items-center gap-2">

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  `inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4`,
+  `inline-flex shrink-0 items-center justify-center gap-2 rounded-full text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4`,
   {
     variants: {
       variant: {
@@ -17,15 +17,16 @@ const buttonVariants = cva(
         ghost: `hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50`,
         link: `text-primary underline-offset-4 hover:underline`,
       },
-      // Glass capsules (EXP-269): the small/pill-like sizes are fully rounded
-      // (mobile glassButton parity); default/lg form CTAs stay rectangles.
+      // Glass capsules (EXP-616): EVERY size is fully rounded now — the base
+      // `rounded-full` covers them all (mobile glassButton parity), including
+      // the default/lg form CTAs that used to stay rectangles (EXP-269).
       size: {
         default: `h-9 px-4 py-2 has-[>svg]:px-3`,
-        xs: `h-6 gap-1 rounded-full px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3`,
-        sm: `h-8 gap-1.5 rounded-full px-3 has-[>svg]:px-2.5`,
-        lg: `h-10 rounded-md px-6 has-[>svg]:px-4`,
-        icon: `size-9 rounded-full`,
-        "icon-xs": `size-6 rounded-full [&_svg:not([class*='size-'])]:size-3`,
+        xs: `h-6 gap-1 px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3`,
+        sm: `h-8 gap-1.5 px-3 has-[>svg]:px-2.5`,
+        lg: `h-10 px-6 has-[>svg]:px-4`,
+        icon: `size-9`,
+        "icon-xs": `size-6 [&_svg:not([class*='size-'])]:size-3`,
       },
     },
     defaultVariants: {

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -12,6 +12,7 @@ const buttonVariants = cva(
         default: `bg-primary text-primary-foreground hover:bg-primary/90`,
         destructive: `bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40`,
         outline: `border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50`,
+        glass: `border border-glass-stroke-card bg-glass-card text-foreground/70 hover:bg-glass-active hover:text-foreground`,
         secondary: `bg-secondary text-secondary-foreground hover:bg-secondary/80`,
         ghost: `hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50`,
         link: `text-primary underline-offset-4 hover:underline`,

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<`div`>) {
     <div
       data-slot="card"
       className={cn(
-        `flex flex-col gap-6 rounded-xl border border-glass-stroke-card bg-glass-card py-6 text-card-foreground shadow-sm`,
+        `flex flex-col gap-6 rounded-xl border border-glass-stroke-card bg-glass-card backdrop-blur-md py-6 text-card-foreground shadow-sm`,
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -12,7 +12,9 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        `peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary`,
+        // EXP-616: glass box — the strong stroke keeps a 16px unchecked square
+        // legible against the row fill it sits on.
+        `peer size-4 shrink-0 rounded-sm border border-glass-stroke-strong bg-glass-row shadow-none transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary`,
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -111,7 +111,7 @@ function CommandItem({
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        `relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground`,
+        `relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-glass-active data-[selected=true]:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground`,
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -47,12 +47,15 @@ function DialogOverlay({
 // Below `sm` a dialog is one of two things. The DEFAULT is the full-screen
 // page (EXP-255) every dialog has had since then. `mobileSheet` opts into the
 // iOS presentation instead (EXP-616): a large-detent bottom sheet — rounded
-// top edge, the page peeking behind it, sliding up from the bottom. Both arms
+// top edge, the page peeking behind it, sliding up from the bottom. The detent
+// is FIXED at 94dvh rather than content-sized: a sheet that shrank to its
+// content read as a cut-off page, and a definite height is also what lets the
+// panel's `flex-1 min-h-0` body scroll instead of clip. Both arms
 // carry their OWN mobile-only classes so nothing leaks between them; from `sm`
 // up the two are identical (the shared string below), which is why the sheet
 // arm re-states the `sm:` padding and zoom the page arm owns unprefixed.
 const MOBILE_PAGE = `inset-0 bg-background p-6 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95`
-const MOBILE_SHEET = `max-sm:inset-x-0 max-sm:bottom-0 max-sm:max-h-[92dvh] max-sm:rounded-t-3xl max-sm:border-t max-sm:border-glass-stroke-card max-sm:bg-card/85 max-sm:p-4 max-sm:pb-[max(1rem,env(safe-area-inset-bottom))] max-sm:backdrop-blur-2xl max-sm:data-[state=closed]:slide-out-to-bottom-1/2 max-sm:data-[state=open]:slide-in-from-bottom-1/2 sm:p-6 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95`
+const MOBILE_SHEET = `max-sm:inset-x-0 max-sm:bottom-0 max-sm:h-[94dvh] max-sm:rounded-t-3xl max-sm:border-t max-sm:border-glass-stroke-card max-sm:bg-card/85 max-sm:p-4 max-sm:pb-[max(1rem,env(safe-area-inset-bottom))] max-sm:backdrop-blur-2xl max-sm:data-[state=closed]:slide-out-to-bottom-1/2 max-sm:data-[state=open]:slide-in-from-bottom-1/2 sm:p-6 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95`
 
 function DialogContent({
   className,
@@ -83,8 +86,8 @@ function DialogContent({
           // inset-0, no rounding/border — the same flex column, just against
           // a definite 100dvh height, so the body scrolls and the action
           // buttons stay reachable at the bottom of the phone screen; opting
-          // into `mobileSheet` swaps that arm for a bottom sheet whose height
-          // follows its content up to 92dvh (see MOBILE_PAGE/MOBILE_SHEET
+          // into `mobileSheet` swaps that arm for a bottom sheet with a fixed
+          // 94dvh detent (see MOBILE_PAGE/MOBILE_SHEET
           // above). From `sm` up it is the centered panel, capped to the
           // viewport — the same for both arms. Callers
           // that reposition or re-cap the panel must sm:-prefix those classes

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -44,13 +44,27 @@ function DialogOverlay({
   )
 }
 
+// Below `sm` a dialog is one of two things. The DEFAULT is the full-screen
+// page (EXP-255) every dialog has had since then. `mobileSheet` opts into the
+// iOS presentation instead (EXP-616): a large-detent bottom sheet — rounded
+// top edge, the page peeking behind it, sliding up from the bottom. Both arms
+// carry their OWN mobile-only classes so nothing leaks between them; from `sm`
+// up the two are identical (the shared string below), which is why the sheet
+// arm re-states the `sm:` padding and zoom the page arm owns unprefixed.
+const MOBILE_PAGE = `inset-0 bg-background p-6 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95`
+const MOBILE_SHEET = `max-sm:inset-x-0 max-sm:bottom-0 max-sm:max-h-[92dvh] max-sm:rounded-t-3xl max-sm:border-t max-sm:border-glass-stroke-card max-sm:bg-card/85 max-sm:p-4 max-sm:pb-[max(1rem,env(safe-area-inset-bottom))] max-sm:backdrop-blur-2xl max-sm:data-[state=closed]:slide-out-to-bottom-1/2 max-sm:data-[state=open]:slide-in-from-bottom-1/2 sm:p-6 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95`
+
 function DialogContent({
   className,
   children,
   showCloseButton = true,
+  mobileSheet = false,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean
+  /** Present the dialog as a bottom sheet below `sm` instead of a full-screen
+   * page (EXP-616). Opt-in — the `sm:` presentation is unchanged either way. */
+  mobileSheet?: boolean
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
@@ -68,8 +82,11 @@ function DialogContent({
           // Below `sm` every dialog is still a full-screen page (EXP-255):
           // inset-0, no rounding/border — the same flex column, just against
           // a definite 100dvh height, so the body scrolls and the action
-          // buttons stay reachable at the bottom of the phone screen. From
-          // `sm` up it is the centered panel, capped to the viewport. Callers
+          // buttons stay reachable at the bottom of the phone screen; opting
+          // into `mobileSheet` swaps that arm for a bottom sheet whose height
+          // follows its content up to 92dvh (see MOBILE_PAGE/MOBILE_SHEET
+          // above). From `sm` up it is the centered panel, capped to the
+          // viewport — the same for both arms. Callers
           // that reposition or re-cap the panel must sm:-prefix those classes
           // so they compose with (and tailwind-merge away) the sm: base here.
           // A column flex container also fixes EXP-178 for free: items take
@@ -81,10 +98,12 @@ function DialogContent({
           // the max-w-* tailwind-merge group — so a caller's sm:max-w-* still
           // caps the panel instead of dropping the gutter.
           // From `sm` up the panel is frosted glass (EXP-269): translucent
-          // card surface + backdrop blur + hairline. Below `sm` it stays the
-          // opaque full-screen page — no phone-sized blur cost, and flat
-          // #0a0a0a is indistinguishable from the gradient top.
-          `fixed inset-0 z-50 flex w-full flex-col gap-4 overflow-hidden bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:inset-auto sm:top-[50%] sm:left-[50%] sm:max-h-[calc(100dvh-2rem)] sm:w-[calc(100%-2rem)] sm:max-w-lg sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-2xl sm:border sm:border-glass-stroke-card sm:bg-card/85 sm:shadow-2xl sm:shadow-black/40 sm:backdrop-blur-2xl`,
+          // card surface + backdrop blur + hairline. Below `sm` the page arm
+          // stays opaque — no phone-sized blur cost, and flat #0a0a0a is
+          // indistinguishable from the gradient top; only the sheet arm, which
+          // deliberately shows the page behind it, pays for the blur.
+          `fixed z-50 flex w-full flex-col gap-4 overflow-hidden shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0 sm:inset-auto sm:top-[50%] sm:left-[50%] sm:max-h-[calc(100dvh-2rem)] sm:w-[calc(100%-2rem)] sm:max-w-lg sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-2xl sm:border sm:border-glass-stroke-card sm:bg-card/85 sm:shadow-2xl sm:shadow-black/40 sm:backdrop-blur-2xl`,
+          mobileSheet ? MOBILE_SHEET : MOBILE_PAGE,
           className
         )}
         {...props}

--- a/apps/web/src/components/ui/glass-rows.tsx
+++ b/apps/web/src/components/ui/glass-rows.tsx
@@ -88,9 +88,11 @@ type GlassPickerOption = {
 
 // The row shell shared by both arms. On the desktop arm these must BEAT the
 // stock SelectTrigger classes: `data-[size=default]:h-9` only loses to the
-// same data-variant, and `dark:bg-input/30` / `dark:hover:bg-input/50` only
-// lose to dark:-prefixed classes (dark is force-enabled app-wide).
-const GLASS_PICKER_ROW = `flex w-full items-center gap-3 rounded-none border-0 bg-transparent px-4 py-3 shadow-none focus-visible:border-0 focus-visible:ring-0 data-[size=default]:h-auto dark:bg-transparent dark:hover:bg-glass-active/50`
+// same data-variant. Since EXP-616 the trigger's fill/hover are unprefixed
+// (`bg-glass-row` / `hover:bg-glass-active/50`), so a plain `bg-transparent`
+// clears the fill and the hover is inherited rather than restated — the row
+// draws the group's own fill one level up.
+const GLASS_PICKER_ROW = `flex w-full items-center gap-3 rounded-none border-0 bg-transparent px-4 py-3 shadow-none focus-visible:border-0 focus-visible:ring-0 data-[size=default]:h-auto`
 
 function GlassPickerRow({
   label,

--- a/apps/web/src/components/ui/glass-rows.tsx
+++ b/apps/web/src/components/ui/glass-rows.tsx
@@ -1,0 +1,255 @@
+import * as React from "react"
+import { Check, ChevronRight } from "lucide-react"
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Sheet, SheetContent } from "@/components/ui/sheet"
+import { Switch } from "@/components/ui/switch"
+import { useIsMobile } from "@/hooks/use-mobile"
+import { cn } from "@/lib/utils"
+
+// EXP-616 — web ports of the iOS glass vocabulary: the row/section ladder from
+// GlassTheme.swift (plain-text section headers, 10px glass rows, the grouped
+// form card with hairline dividers) and the picker/toggle rows from
+// GlassOptionRows.swift (label leading, value trailing, whole row tappable).
+// `border-glass-stroke` IS the row stroke: styles.css maps
+// `--color-glass-stroke: var(--glass-stroke-row)`, and there is no
+// `glass-stroke-row` colour utility.
+
+function GlassSectionHeader({
+  label,
+  count,
+  trailing,
+  className,
+}: {
+  label: string
+  count?: number
+  trailing?: React.ReactNode
+  className?: string
+}) {
+  return (
+    <div
+      data-slot="glass-section-header"
+      className={cn(`flex items-center gap-1.5 px-1 pt-1 pb-2`, className)}
+    >
+      <span className="text-sm font-medium text-foreground/70">{label}</span>
+      {count !== undefined && (
+        <span className="text-xs text-foreground/50">{count}</span>
+      )}
+      {trailing && (
+        <div className="ml-auto flex items-center gap-1.5">{trailing}</div>
+      )}
+    </div>
+  )
+}
+
+function GlassRow({
+  interactive = false,
+  className,
+  ...props
+}: React.ComponentProps<`div`> & { interactive?: boolean }) {
+  return (
+    <div
+      data-slot="glass-row"
+      className={cn(
+        `flex items-center gap-3 rounded-md border border-glass-stroke bg-glass-row p-3`,
+        interactive &&
+          `cursor-pointer transition-colors duration-fast hover:bg-glass-active/50`,
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function GlassGroup({ className, ...props }: React.ComponentProps<`div`>) {
+  return (
+    <div
+      data-slot="glass-group"
+      className={cn(
+        `flex flex-col divide-y divide-glass-stroke overflow-hidden rounded-lg bg-glass-row`,
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+type GlassPickerOption = {
+  value: string
+  label: React.ReactNode
+  disabled?: boolean
+}
+
+// The row shell shared by both arms. On the desktop arm these must BEAT the
+// stock SelectTrigger classes: `data-[size=default]:h-9` only loses to the
+// same data-variant, and `dark:bg-input/30` / `dark:hover:bg-input/50` only
+// lose to dark:-prefixed classes (dark is force-enabled app-wide).
+const GLASS_PICKER_ROW = `flex w-full items-center gap-3 rounded-none border-0 bg-transparent px-4 py-3 shadow-none focus-visible:border-0 focus-visible:ring-0 data-[size=default]:h-auto dark:bg-transparent dark:hover:bg-glass-active/50`
+
+function GlassPickerRow({
+  label,
+  value,
+  onValueChange,
+  options,
+  placeholder,
+  disabled,
+  renderValue,
+  className,
+}: {
+  label: string
+  value: string | undefined
+  onValueChange: (v: string) => void
+  options: GlassPickerOption[]
+  placeholder?: string
+  disabled?: boolean
+  renderValue?: (option: GlassPickerOption | undefined) => React.ReactNode
+  className?: string
+}) {
+  const isMobile = useIsMobile()
+  const [open, setOpen] = React.useState(false)
+  const selected = options.find((option) => option.value === value)
+
+  if (isMobile) {
+    return (
+      <>
+        <button
+          type="button"
+          data-slot="glass-picker-row"
+          disabled={disabled}
+          onClick={() => setOpen(true)}
+          className={cn(
+            `flex w-full items-center gap-3 px-4 py-3 text-left transition-colors duration-fast hover:bg-glass-active/50 disabled:pointer-events-none disabled:opacity-50`,
+            className
+          )}
+        >
+          <span className="text-sm text-foreground">{label}</span>
+          <span className="ml-auto truncate text-sm text-foreground/70">
+            {renderValue
+              ? renderValue(selected)
+              : (selected?.label ?? placeholder)}
+          </span>
+          <ChevronRight className="size-3.5 shrink-0 text-foreground/50" />
+        </button>
+        <Sheet open={open} onOpenChange={setOpen}>
+          <SheetContent
+            side="bottom"
+            showCloseButton={false}
+            className="flex max-h-[85dvh] flex-col gap-0 rounded-t-xl p-0 pb-[env(safe-area-inset-bottom)]"
+          >
+            <div className="px-4 pt-3 pb-2 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+              {label}
+            </div>
+            <div className="overflow-y-auto p-1">
+              {options.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  disabled={option.disabled}
+                  className="flex h-11 w-full items-center gap-3 rounded-md px-3 text-sm hover:bg-glass-row disabled:pointer-events-none disabled:opacity-50"
+                  onClick={() => {
+                    onValueChange(option.value)
+                    setOpen(false)
+                  }}
+                >
+                  <span className="flex-1 truncate text-left">
+                    {option.label}
+                  </span>
+                  {option.value === value && (
+                    <Check className="size-4 shrink-0 text-muted-foreground" />
+                  )}
+                </button>
+              ))}
+            </div>
+          </SheetContent>
+        </Sheet>
+      </>
+    )
+  }
+
+  return (
+    <Select value={value} onValueChange={onValueChange} disabled={disabled}>
+      <SelectTrigger
+        data-slot="glass-picker-row"
+        className={cn(GLASS_PICKER_ROW, className)}
+      >
+        <span className="text-sm text-foreground">{label}</span>
+        <span className="ml-auto truncate text-sm text-foreground/70">
+          {renderValue ? (
+            (renderValue(selected) ?? placeholder)
+          ) : (
+            <SelectValue placeholder={placeholder} />
+          )}
+        </span>
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((option) => (
+          <SelectItem
+            key={option.value}
+            value={option.value}
+            disabled={option.disabled}
+          >
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+function GlassToggleRow({
+  id,
+  label,
+  checked,
+  onCheckedChange,
+  disabled,
+  description,
+  className,
+}: {
+  id: string
+  label: React.ReactNode
+  checked: boolean
+  onCheckedChange: (v: boolean) => void
+  disabled?: boolean
+  description?: React.ReactNode
+  className?: string
+}) {
+  return (
+    <label
+      htmlFor={id}
+      data-slot="glass-toggle-row"
+      className={cn(
+        `flex cursor-pointer items-center gap-3 px-4 py-3`,
+        disabled && `cursor-not-allowed opacity-50`,
+        className
+      )}
+    >
+      <span className="flex flex-1 flex-col gap-0.5">
+        <span className="text-sm font-normal">{label}</span>
+        {description && (
+          <span className="text-xs text-foreground/50">{description}</span>
+        )}
+      </span>
+      <Switch
+        id={id}
+        checked={checked}
+        onCheckedChange={onCheckedChange}
+        disabled={disabled}
+      />
+    </label>
+  )
+}
+
+export {
+  GlassSectionHeader,
+  GlassRow,
+  GlassGroup,
+  GlassPickerRow,
+  GlassToggleRow,
+}
+export type { GlassPickerOption }

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -10,7 +10,9 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<`input`>>(
         type={type}
         data-slot="input"
         className={cn(
-          `h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30`,
+          // EXP-616: glass by default — the row fill + row stroke ARE the field,
+          // so callers never re-dress an Input locally.
+          `h-9 w-full min-w-0 rounded-md border border-glass-stroke bg-glass-row px-3 py-1 text-base shadow-none transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm`,
           `focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50`,
           `aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40`,
           className

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -37,7 +37,8 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        `flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground`,
+        // EXP-616: glass by default, matching Input/Textarea.
+        `flex w-fit items-center justify-between gap-2 rounded-md border border-glass-stroke bg-glass-row px-3 py-2 text-sm whitespace-nowrap shadow-none transition-[color,box-shadow] outline-none hover:bg-glass-active/50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground`,
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -15,15 +15,21 @@ function Switch({
       data-slot="switch"
       data-size={size}
       className={cn(
-        `peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80`,
+        // EXP-616: the default track grows one notch toward the iOS toggle
+        // (20×36 with a 16px thumb); size=sm stays untouched for dense rows.
+        `peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-none transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-5 data-[size=default]:w-9 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-primary data-[state=unchecked]:bg-glass-active`,
         className
       )}
       {...props}
     >
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
+        // The checked offset is (track width - 2px of border - thumb width),
+        // written relative to the thumb's own width: sm is 24-2-12 = 10px =
+        // calc(100% - 2px); the widened default is 36-2-16 = 18px =
+        // calc(100% + 2px).
         className={cn(
-          `pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground`
+          `pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 group-data-[size=default]/switch:data-[state=checked]:translate-x-[calc(100%+2px)] dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground`
         )}
       />
     </SwitchPrimitive.Root>

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -42,7 +42,7 @@ function TableFooter({ className, ...props }: React.ComponentProps<`tfoot`>) {
     <tfoot
       data-slot="table-footer"
       className={cn(
-        `border-t bg-muted/50 font-medium [&>tr]:last:border-b-0`,
+        `border-t bg-glass-row font-medium [&>tr]:last:border-b-0`,
         className
       )}
       {...props}
@@ -55,7 +55,7 @@ function TableRow({ className, ...props }: React.ComponentProps<`tr`>) {
     <tr
       data-slot="table-row"
       className={cn(
-        `border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted`,
+        `border-b transition-colors hover:bg-glass-row data-[state=selected]:bg-glass-active`,
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -7,7 +7,8 @@ function Textarea({ className, ...props }: React.ComponentProps<`textarea`>) {
     <textarea
       data-slot="textarea"
       className={cn(
-        `flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40`,
+        // EXP-616: glass by default, matching Input.
+        `flex field-sizing-content min-h-16 w-full rounded-md border border-glass-stroke bg-glass-row px-3 py-2 text-base shadow-none transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:aria-invalid:ring-destructive/40`,
         className
       )}
       {...props}

--- a/apps/web/src/lib/builtin-actions.ts
+++ b/apps/web/src/lib/builtin-actions.ts
@@ -63,7 +63,7 @@ const CREATE_ACTION_INPUTS: ActionInputDef[] = [
     label: `Name`,
     type: `text`,
     required: false,
-    placeholder: `Leave blank to let the agent name it`,
+    placeholder: `Name (optional)`,
   },
   { key: `repo`, label: `Repository`, type: `repo`, required: false },
   // EXP-273: the user picks the new action's glyph up front and the

--- a/apps/web/src/routes/_authenticated/admin/route.tsx
+++ b/apps/web/src/routes/_authenticated/admin/route.tsx
@@ -1,5 +1,8 @@
 import { createFileRoute, Link, Outlet, redirect } from "@tanstack/react-router"
+import type { LinkProps } from "@tanstack/react-router"
+import type React from "react"
 import { useEffect, useState } from "react"
+import type { LucideIcon } from "lucide-react"
 import {
   Activity,
   ArrowLeft,
@@ -44,11 +47,40 @@ function useIsCloud(): boolean {
   return isCloud
 }
 
+function AdminNavLink({
+  to,
+  exact,
+  icon: Icon,
+  children,
+}: {
+  to: LinkProps[`to`]
+  exact?: boolean
+  icon: LucideIcon
+  children: React.ReactNode
+}) {
+  return (
+    <Link
+      to={to}
+      activeOptions={exact ? { exact: true } : undefined}
+      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1 text-sm font-medium whitespace-nowrap transition-colors"
+      activeProps={{
+        className: `border-glass-stroke-active bg-glass-active text-foreground`,
+      }}
+      inactiveProps={{
+        className: `border-transparent text-muted-foreground hover:text-foreground`,
+      }}
+    >
+      <Icon className="h-4 w-4" />
+      {children}
+    </Link>
+  )
+}
+
 function AdminLayout() {
   const isCloud = useIsCloud()
   return (
     <div className="min-h-screen flex flex-col">
-      <header className="flex items-center gap-3 border-b px-4 h-12">
+      <header className="flex items-center gap-3 px-4 h-12">
         <Button asChild variant="ghost" size="sm" className="-ml-2 shrink-0">
           <Link to="/">
             <ArrowLeft className="h-4 w-4" />
@@ -60,58 +92,33 @@ function AdminLayout() {
           <Shield className="h-4 w-4" />
           <span className="hidden sm:inline">Admin</span>
         </div>
-        {/* The entries outgrow narrow viewports — scroll the nav instead of
-            clipping it (buttons stay nowrap, so without this they vanish
-            off-screen on mobile). */}
-        <nav className="ml-4 flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
-          <Button asChild variant="ghost" size="sm">
-            <Link
-              to="/admin"
-              activeOptions={{ exact: true }}
-              activeProps={{ className: `bg-accent` }}
-            >
-              <LayoutDashboard className="h-4 w-4" />
-              Overview
-            </Link>
-          </Button>
-          <Button asChild variant="ghost" size="sm">
-            <Link
-              to="/admin/performance"
-              activeProps={{ className: `bg-accent` }}
-            >
-              <Activity className="h-4 w-4" />
-              Performance
-            </Link>
-          </Button>
+        {/* EXP-616: iOS capsule segmented control (TabsList/TabsTrigger
+            parity), hand-mirrored because these are route links, not stateful
+            tabs. The entries outgrow narrow viewports — scroll the strip
+            instead of clipping it (pills stay nowrap, so without this they
+            vanish off-screen on mobile); the scrollbar itself is hidden so the
+            capsule edge stays clean. */}
+        <nav className="ml-4 inline-flex min-w-0 items-center gap-1 overflow-x-auto rounded-full border border-glass-stroke-section bg-glass-section p-[3px] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          <AdminNavLink to="/admin" exact icon={LayoutDashboard}>
+            Overview
+          </AdminNavLink>
+          <AdminNavLink to="/admin/performance" icon={Activity}>
+            Performance
+          </AdminNavLink>
           {isCloud && (
-            <Button asChild variant="ghost" size="sm">
-              <Link
-                to="/admin/conversions"
-                activeProps={{ className: `bg-accent` }}
-              >
-                <TrendingUp className="h-4 w-4" />
-                Conversions
-              </Link>
-            </Button>
+            <AdminNavLink to="/admin/conversions" icon={TrendingUp}>
+              Conversions
+            </AdminNavLink>
           )}
-          <Button asChild variant="ghost" size="sm">
-            <Link to="/admin/users" activeProps={{ className: `bg-accent` }}>
-              <Users className="h-4 w-4" />
-              Users
-            </Link>
-          </Button>
-          <Button asChild variant="ghost" size="sm">
-            <Link to="/admin/teams" activeProps={{ className: `bg-accent` }}>
-              <Building2 className="h-4 w-4" />
-              Teams
-            </Link>
-          </Button>
-          <Button asChild variant="ghost" size="sm">
-            <Link to="/admin/email" activeProps={{ className: `bg-accent` }}>
-              <MailWarning className="h-4 w-4" />
-              Email
-            </Link>
-          </Button>
+          <AdminNavLink to="/admin/users" icon={Users}>
+            Users
+          </AdminNavLink>
+          <AdminNavLink to="/admin/teams" icon={Building2}>
+            Teams
+          </AdminNavLink>
+          <AdminNavLink to="/admin/email" icon={MailWarning}>
+            Email
+          </AdminNavLink>
         </nav>
       </header>
       <main className="flex-1">

--- a/apps/web/src/routes/t/$teamSlug/agents/index.tsx
+++ b/apps/web/src/routes/t/$teamSlug/agents/index.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react"
 import { createFileRoute, redirect } from "@tanstack/react-router"
 import { MyMachines } from "@/components/my-machines"
-import { SectionLabel, SessionRow } from "@/components/agent-session-row"
+import { SessionRow } from "@/components/agent-session-row"
+import { GlassSectionHeader } from "@/components/ui/glass-rows"
 import { useSteerConfig } from "@/components/agent-session"
 import { useAgentDock } from "@/components/agent-dock/agent-dock-provider"
 import { TeamActionsPanel } from "@/components/team-actions-panel"
@@ -91,19 +92,18 @@ function AgentsPage() {
           (isLoading ? (
             <div className="text-muted-foreground p-6 text-sm">Loading…</div>
           ) : running.length > 0 ? (
-            <div className="mb-4">
-              <SectionLabel label="Running" count={running.length} />
-              {running.map((row) => (
-                <SessionRow
-                  key={row.session.id}
-                  row={row}
-                  // EXP-312: live sessions are owner-only, and every row in
-                  // this list is already the caller's own.
-                  canWatch={steerEnabled}
-                  teamSlug={teamSlug}
-                  onOpen={() => dock?.openDock(row.session.id)}
-                />
-              ))}
+            <div className="mb-6">
+              <GlassSectionHeader label="Running" />
+              <div className="flex flex-col gap-2">
+                {running.map((row) => (
+                  <SessionRow
+                    key={row.session.id}
+                    row={row}
+                    teamSlug={teamSlug}
+                    onOpen={() => dock?.openDock(row.session.id)}
+                  />
+                ))}
+              </div>
             </div>
           ) : null)}
 

--- a/apps/web/src/routes/t/$teamSlug/inbox/index.tsx
+++ b/apps/web/src/routes/t/$teamSlug/inbox/index.tsx
@@ -6,6 +6,7 @@ import {
   MyIssuesView,
 } from "@/components/my-issues-view"
 import { Button } from "@/components/ui/button"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { conceptIcon } from "@/lib/icons.generated"
 import { useSession } from "@/hooks/use-session"
 import { useUnreadNotificationCount } from "@/hooks/use-unread-notifications"
@@ -16,9 +17,8 @@ import {
   issueFiltersFromSearch,
   parseIssueFilterSearch,
 } from "@/lib/filters"
-import { cn } from "@/lib/utils"
 
-// EXP-525: the tab pills carry the same registry glyphs the mobile My Work
+// EXP-525: the tab segments carry the same registry glyphs the mobile My Work
 // segments and the desktop rail use.
 const InboxTabIcon = conceptIcon(`nav-inbox`)
 const MyIssuesTabIcon = conceptIcon(`ui-assignee`)
@@ -51,18 +51,13 @@ export const Route = createFileRoute(`/t/$teamSlug/inbox/`)({
   component: InboxPage,
 })
 
-function UnreadCountPill({ active }: { active: boolean }) {
+// EXP-616: inside the capsule segment the count is a plain trailing number
+// (the GlassSectionHeader idiom), not a second pill nested in a pill.
+function UnreadTabCount() {
   const unread = useUnreadNotificationCount()
   if (unread === 0) return null
   return (
-    <span
-      className={cn(
-        `rounded-full px-1.5 py-px text-[10px] font-medium tabular-nums`,
-        active
-          ? `bg-primary text-primary-foreground`
-          : `bg-muted text-muted-foreground`
-      )}
-    >
+    <span className="text-xs text-foreground/50 tabular-nums">
       {unread > 99 ? `99+` : unread}
     </span>
   )
@@ -127,37 +122,25 @@ function InboxPage() {
           separate filter bar left the list flush against the tabs, so the row
           carries its own bottom padding. */}
       <div className="flex shrink-0 items-center justify-between px-4 pt-3 pb-2 md:px-6">
-        <div className="flex items-center gap-1">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setTab(`inbox`)}
-            className={cn(
-              `shrink-0 gap-1.5 rounded-full h-7 px-3 text-xs`,
-              tab === `inbox`
-                ? `bg-accent text-foreground font-medium`
-                : `text-muted-foreground hover:text-foreground`
-            )}
-          >
-            <InboxTabIcon className="size-3.5 shrink-0" />
-            Inbox
-            <UnreadCountPill active={tab === `inbox`} />
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setTab(`my-issues`)}
-            className={cn(
-              `shrink-0 gap-1.5 rounded-full h-7 px-3 text-xs`,
-              tab === `my-issues`
-                ? `bg-accent text-foreground font-medium`
-                : `text-muted-foreground hover:text-foreground`
-            )}
-          >
-            <MyIssuesTabIcon className="size-3.5 shrink-0" />
-            My Issues
-          </Button>
-        </div>
+        {/* EXP-616: the capsule segmented control, still URL-driven — the
+            controlled value is the parsed ?tab and every change navigates. */}
+        <Tabs
+          value={tab}
+          onValueChange={(next) => setTab(next as `inbox` | `my-issues`)}
+          className="w-fit shrink-0"
+        >
+          <TabsList>
+            <TabsTrigger value="inbox" className="px-3">
+              <InboxTabIcon />
+              Inbox
+              <UnreadTabCount />
+            </TabsTrigger>
+            <TabsTrigger value="my-issues" className="px-3">
+              <MyIssuesTabIcon />
+              My Issues
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
         {tab === `inbox` ? (
           <MarkAllReadButton />
         ) : (

--- a/apps/web/src/routes/t/$teamSlug/reviews/index.tsx
+++ b/apps/web/src/routes/t/$teamSlug/reviews/index.tsx
@@ -177,10 +177,12 @@ function ReviewsPage() {
     <div className="mx-auto flex h-full w-full max-w-3xl flex-col px-4 py-4">
       <div className={`flex-1 overflow-y-auto ${TAB_BAR_CLEARANCE}`}>
         {isLoading ? (
-          <div className="text-muted-foreground p-6 text-sm">Loading…</div>
+          <div className="text-muted-foreground px-1 py-6 text-sm">Loading…</div>
         ) : count === 0 ? (
           externalLoading ? (
-            <div className="text-muted-foreground p-6 text-sm">Loading…</div>
+            <div className="text-muted-foreground px-1 py-6 text-sm">
+              Loading…
+            </div>
           ) : (
             <EmptyState
               icon={GitPullRequest}
@@ -190,185 +192,192 @@ function ReviewsPage() {
           )
         ) : (
           <>
-          {groups.map((group) => (
-            <div key={group.board.id} className="mb-4">
-              <div
-                className="flex items-center gap-1.5 rounded-t-md border-b border-border/50 bg-zinc-500/10 px-3 py-1.5"
-              >
-                <BoardGlyph board={group.board} className="size-3.5" />
-                <span className="text-sm font-medium">
-                  {group.board.name}
-                </span>
-                <span className="text-xs text-muted-foreground">
-                  {group.entries.length}
-                </span>
-              </div>
+            {groups.map((group) => (
+              <div key={group.board.id} className="mb-6">
+                {/* Plain-text section header (EXP-616) — GlassSectionHeader's
+                    recipe, inlined because the label area carries the board
+                    glyph as well as its name. */}
+                <div className="flex items-center gap-1.5 px-1 pt-1 pb-2">
+                  <BoardGlyph board={group.board} className="size-3.5" />
+                  <span className="text-sm font-medium text-foreground/70">
+                    {group.board.name}
+                  </span>
+                  <span className="text-xs text-foreground/50">
+                    {group.entries.length}
+                  </span>
+                </div>
 
-              {group.entries.map((entry) => {
-                const issue = entry.issue
-                const isBatch = entry.issues.length > 1
-                const merging = mergingIds.has(entry.key)
-                const mergeError = mergeErrors[entry.key]
-                // The recovery run rebases the PR's branch, so it needs one
-                // recorded — the same guard the desktop applies.
-                const canFixConflicts = Boolean(
-                  mergeError && issue.branch && steerEnabled
-                )
-                return (
-                  <div
-                    key={entry.key}
-                    className="group/row grid cursor-pointer grid-cols-[1.5rem_4.5rem_1fr_auto] items-center border-b border-border/30 px-3 py-1.5 hover:bg-muted/50"
-                    onClick={() => openReview(issue.identifier)}
-                    data-testid={`review-row-${issue.identifier}`}
-                  >
-                    <GitPullRequest className="h-4 w-4 text-emerald-500" />
-                    <span className="truncate font-mono text-xs text-muted-foreground">
-                      {isBatch && issue.prNumber
-                        ? `#${issue.prNumber}`
-                        : issue.identifier}
-                    </span>
-                    <div className="min-w-0 pr-2">
-                      <div className="truncate text-sm">
-                        {isBatch ? (
-                          <>
-                            {`${entry.issues.length} issues`}
-                            <span className="ml-2 font-mono text-xs text-muted-foreground">
-                              {entry.issues
-                                .map((linked) => linked.identifier)
-                                .join(`, `)}
+                <div className="flex flex-col gap-2">
+                  {group.entries.map((entry) => {
+                    const issue = entry.issue
+                    const isBatch = entry.issues.length > 1
+                    const merging = mergingIds.has(entry.key)
+                    const mergeError = mergeErrors[entry.key]
+                    // The recovery run rebases the PR's branch, so it needs one
+                    // recorded — the same guard the desktop applies.
+                    const canFixConflicts = Boolean(
+                      mergeError && issue.branch && steerEnabled
+                    )
+                    return (
+                      <div
+                        key={entry.key}
+                        className="group/row grid cursor-pointer grid-cols-[1.5rem_4.5rem_1fr_auto] items-center rounded-md border border-glass-stroke bg-glass-row p-3 transition-colors duration-fast hover:bg-glass-active/50"
+                        onClick={() => openReview(issue.identifier)}
+                        data-testid={`review-row-${issue.identifier}`}
+                      >
+                        <GitPullRequest className="h-4 w-4 text-emerald-500" />
+                        <span className="truncate font-mono text-xs text-muted-foreground">
+                          {isBatch && issue.prNumber
+                            ? `#${issue.prNumber}`
+                            : issue.identifier}
+                        </span>
+                        <div className="min-w-0 pr-2">
+                          <div className="truncate text-sm">
+                            {isBatch ? (
+                              <>
+                                {`${entry.issues.length} issues`}
+                                <span className="ml-2 font-mono text-xs text-muted-foreground">
+                                  {entry.issues
+                                    .map((linked) => linked.identifier)
+                                    .join(`, `)}
+                                </span>
+                              </>
+                            ) : (
+                              issue.title
+                            )}
+                          </div>
+                          {issue.branch && (
+                            <div className="truncate font-mono text-xs text-muted-foreground">
+                              {issue.branch}
+                            </div>
+                          )}
+                        </div>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          disabled={merging}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            setMergeTarget(entry)
+                          }}
+                        >
+                          {merging ? (
+                            <>
+                              <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                              Merging…
+                            </>
+                          ) : (
+                            <>
+                              <GitMerge className="h-3.5 w-3.5" />
+                              Merge
+                            </>
+                          )}
+                        </Button>
+                        {/* The refusal captions its own row (EXP-323) —
+                            spanning the grid so the full GitHub message stays
+                            readable — with the recovery run right beside it. */}
+                        {mergeError && (
+                          <div className="col-span-4 flex flex-wrap items-center gap-2 pt-2">
+                            <span className="text-destructive text-xs">
+                              {mergeError}
                             </span>
-                          </>
-                        ) : (
-                          issue.title
+                            {canFixConflicts && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  setFixTarget(entry)
+                                }}
+                              >
+                                <GitBranch className="h-3.5 w-3.5" />
+                                Fix conflicts
+                              </Button>
+                            )}
+                          </div>
                         )}
                       </div>
-                      {issue.branch && (
-                        <div className="truncate font-mono text-xs text-muted-foreground">
-                          {issue.branch}
-                        </div>
-                      )}
-                    </div>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      disabled={merging}
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        setMergeTarget(entry)
-                      }}
-                    >
-                      {merging ? (
-                        <>
-                          <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-                          Merging…
-                        </>
-                      ) : (
-                        <>
-                          <GitMerge className="h-3.5 w-3.5" />
-                          Merge
-                        </>
-                      )}
-                    </Button>
-                    {/* The refusal captions its own row (EXP-323) — spanning
-                        the grid so the full GitHub message stays readable —
-                        with the conflict-recovery run right beside it. */}
-                    {mergeError && (
-                      <div className="col-span-4 flex flex-wrap items-center gap-2 pt-1.5">
-                        <span className="text-destructive text-xs">
-                          {mergeError}
-                        </span>
-                        {canFixConflicts && (
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              setFixTarget(entry)
-                            }}
-                          >
-                            <GitBranch className="h-3.5 w-3.5" />
-                            Fix conflicts
-                          </Button>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                )
-              })}
-            </div>
-          ))}
-
-          {externalGroups.map((group) => (
-            <div key={group.repositoryId} className="mb-4">
-              <div
-                className="flex items-center gap-1.5 rounded-t-md border-b border-border/50 bg-zinc-500/10 px-3 py-1.5"
-              >
-                <GitPullRequest className="h-2.5 w-2.5 shrink-0 text-muted-foreground" />
-                <span className="text-sm font-medium">{group.fullName}</span>
-                <span className="text-xs text-muted-foreground">
-                  not linked to an issue · {group.pulls.length}
-                </span>
+                    )
+                  })}
+                </div>
               </div>
+            ))}
 
-              {group.pulls.map((pull) => {
-                const key = externalPullKey(group.repositoryId, pull.number)
-                const merging = mergingIds.has(key)
-                return (
-                  <div
-                    key={pull.number}
-                    className="group/row grid cursor-pointer grid-cols-[1.5rem_4.5rem_1fr_auto] items-center border-b border-border/30 px-3 py-1.5 hover:bg-muted/50"
-                    onClick={() =>
-                      window.open(pull.url, `_blank`, `noopener,noreferrer`)
-                    }
-                    data-testid={`review-pull-${group.fullName}-${pull.number}`}
-                  >
-                    <GitPullRequest className="h-4 w-4 text-emerald-500" />
-                    <span className="truncate font-mono text-xs text-muted-foreground">
-                      #{pull.number}
-                    </span>
-                    <div className="min-w-0 pr-2">
-                      <div className="flex min-w-0 items-center gap-2">
-                        <span className="min-w-0 truncate text-sm">
-                          {pull.title}
+            {externalGroups.map((group) => (
+              <div key={group.repositoryId} className="mb-6">
+                <div className="flex items-center gap-1.5 px-1 pt-1 pb-2">
+                  <GitPullRequest className="h-2.5 w-2.5 shrink-0 text-foreground/50" />
+                  <span className="text-sm font-medium text-foreground/70">
+                    {group.fullName}
+                  </span>
+                  <span className="text-xs text-foreground/50">
+                    not linked to an issue · {group.pulls.length}
+                  </span>
+                </div>
+
+                <div className="flex flex-col gap-2">
+                  {group.pulls.map((pull) => {
+                    const key = externalPullKey(group.repositoryId, pull.number)
+                    const merging = mergingIds.has(key)
+                    return (
+                      <div
+                        key={pull.number}
+                        className="group/row grid cursor-pointer grid-cols-[1.5rem_4.5rem_1fr_auto] items-center rounded-md border border-glass-stroke bg-glass-row p-3 transition-colors duration-fast hover:bg-glass-active/50"
+                        onClick={() =>
+                          window.open(pull.url, `_blank`, `noopener,noreferrer`)
+                        }
+                        data-testid={`review-pull-${group.fullName}-${pull.number}`}
+                      >
+                        <GitPullRequest className="h-4 w-4 text-emerald-500" />
+                        <span className="truncate font-mono text-xs text-muted-foreground">
+                          #{pull.number}
                         </span>
-                        {pull.draft && <Badge variant="secondary">Draft</Badge>}
-                      </div>
-                      {pull.branch && (
-                        <div className="truncate font-mono text-xs text-muted-foreground">
-                          {pull.branch}
+                        <div className="min-w-0 pr-2">
+                          <div className="flex min-w-0 items-center gap-2">
+                            <span className="min-w-0 truncate text-sm">
+                              {pull.title}
+                            </span>
+                            {pull.draft && (
+                              <Badge variant="secondary">Draft</Badge>
+                            )}
+                          </div>
+                          {pull.branch && (
+                            <div className="truncate font-mono text-xs text-muted-foreground">
+                              {pull.branch}
+                            </div>
+                          )}
                         </div>
-                      )}
-                    </div>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      disabled={merging || pull.draft}
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        setExternalMergeTarget({
-                          repositoryId: group.repositoryId,
-                          fullName: group.fullName,
-                          pull,
-                        })
-                      }}
-                    >
-                      {merging ? (
-                        <>
-                          <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-                          Merging…
-                        </>
-                      ) : (
-                        <>
-                          <GitMerge className="h-3.5 w-3.5" />
-                          Merge
-                        </>
-                      )}
-                    </Button>
-                  </div>
-                )
-              })}
-            </div>
-          ))}
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          disabled={merging || pull.draft}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            setExternalMergeTarget({
+                              repositoryId: group.repositoryId,
+                              fullName: group.fullName,
+                              pull,
+                            })
+                          }}
+                        >
+                          {merging ? (
+                            <>
+                              <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                              Merging…
+                            </>
+                          ) : (
+                            <>
+                              <GitMerge className="h-3.5 w-3.5" />
+                              Merge
+                            </>
+                          )}
+                        </Button>
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            ))}
           </>
         )}
       </div>

--- a/apps/web/src/routes/t/$teamSlug/settings/route.tsx
+++ b/apps/web/src/routes/t/$teamSlug/settings/route.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, Outlet, redirect } from "@tanstack/react-router"
-import { Button } from "@/components/ui/button"
+import { Fragment } from "react"
 import { Separator } from "@/components/ui/separator"
 import { TAB_BAR_CLEARANCE } from "@/components/team/mobile-tab-bar"
 import {
@@ -42,33 +42,38 @@ function SettingsLayout() {
             main nav slides out, the settings nav slides in — see
             TeamSidebar/SettingsSidebar), so this in-page nav is the mobile
             horizontally-scrollable row only (group labels hidden there). */}
-        <nav className="flex gap-4 overflow-x-auto md:hidden">
+        {/* EXP-616: iOS capsule segmented control look (TabsList/TabsTrigger
+            parity) — these are route links, not stateful tabs, so the styling
+            is mirrored by hand rather than forcing Radix Tabs semantics onto
+            them. Groups flatten into one strip (their labels were already
+            hidden here); the strip still scrolls horizontally, with the
+            scrollbar itself hidden so the capsule edge stays clean. */}
+        <nav className="inline-flex max-w-full items-center gap-1 self-start overflow-x-auto rounded-full border border-glass-stroke-section bg-glass-section p-[3px] [scrollbar-width:none] md:hidden [&::-webkit-scrollbar]:hidden">
           {SETTINGS_NAV.map((group) => {
             const items = group.items.filter((item) =>
               item.visible(permissions, navContext)
             )
             if (items.length === 0) return null
             return (
-              <div key={group.group} className="flex shrink-0 gap-1">
+              <Fragment key={group.group}>
                 {items.map((item) => (
-                  <Button
+                  <Link
                     key={item.label}
-                    asChild
-                    variant="ghost"
-                    size="sm"
-                    className="justify-start"
+                    to={item.to}
+                    params={{ teamSlug }}
+                    className="inline-flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1 text-sm font-medium whitespace-nowrap transition-colors"
+                    activeProps={{
+                      className: `border-glass-stroke-active bg-glass-active text-foreground`,
+                    }}
+                    inactiveProps={{
+                      className: `border-transparent text-muted-foreground hover:text-foreground`,
+                    }}
                   >
-                    <Link
-                      to={item.to}
-                      params={{ teamSlug }}
-                      activeProps={{ className: `bg-accent` }}
-                    >
-                      <item.icon className="h-4 w-4" />
-                      {item.label}
-                    </Link>
-                  </Button>
+                    <item.icon className="h-4 w-4" />
+                    {item.label}
+                  </Link>
                 ))}
-              </div>
+              </Fragment>
             )
           })}
         </nav>


### PR DESCRIPTION
Makes the web app read like the iOS app — anatomy and feel, not just skin. Stacked on exp/EXP-615 (#506).

## What changed
- **Foundation** (`ui/glass-rows.tsx`): GlassSectionHeader (plain-text headers — the gray SectionLabel bands are gone from every converted surface), GlassRow, GlassGroup, GlassPickerRow (label inside the row; Radix Select on desktop, bottom-sheet options on mobile), GlassToggleRow (trailing switch), plus a `glass` button variant (the iOS CircleIconButton). No token changes — the EXP-269 `--glass-*` set already mirrors iOS GlassTheme, so `design-tokens.test.ts` is untouched.
- **Agents page**: machine + running-session rows are glass cards in gap-2 stacks with plain headers (no counts, iOS parity); circular glass play buttons; bare ellipsis.
- **Launch dialog family**: the shared options pane renders the exact iOS LaunchOptionsSection order (Device card → agent capsule → Model/Effort card → toggle switches); Issues/Actions lists, Chat prompt/repository, create-action and automation dialogs all carded. Heights 34rem→36rem.
- **Feel**: launch/create-action/automation dialogs present as bottom sheets on mobile (rounded-top 24, 92dvh, page peeking behind — opt-in `mobileSheet` on DialogContent); pickers open bottom sheets on mobile instead of anchored dropdowns.
- **Inbox** (capsule tabs + glass notification cards), **Reviews** (plain group headers + card rows), **Support inbox** (glass thread cards, capsule status tabs), **Settings sections** (grouped toggle/picker rows, caption-inside-card text fields, glass list rows), **nav strips** (settings mobile + admin → capsule pills), **issue coding/PR rows** (glass cards).
- **Global controls**: input/textarea/select/checkbox/switch/command/table go glass; Card gains backdrop blur; every button size is a capsule (isolated commit, easy revert).

## Behavior deltas
- Session rows: the Watch button is replaced by a bare info glyph that opens the ISSUE; clicking the row opens the live session (iOS semantics). The identifier link is gone (info icon owns issue nav); `canWatch` prop deleted.
- All wording byte-identical everywhere (cross-client string parity).

## Review
One commit per surface, deliberately — reject a surface and it reverts cleanly. Before/after screenshot pairs for all 16 surfaces × desktop/mobile accompany the review.

Verification: `bun run typecheck` clean; web suite 170 files / 2268 tests green; `design-tokens.test.ts` + `icons.test.ts` unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)