### PR TITLE
fix: Node 26 silently strips every dev response header (and the screenshot lane that could not notice)

### DIFF
--- a/apps/desktop/crates/ui/src/source_control.rs
+++ b/apps/desktop/crates/ui/src/source_control.rs
@@ -744,8 +744,30 @@ impl SourceControlView {
     fn render_body(&mut self, cx: &mut gpui::Context<Self>) -> gpui::AnyElement {
         let theme = cx.theme();
 
-        // Scope not yet resolvable (teams/boards still syncing).
-        if matches!(self.scope_load, Load::Loading) && self.scope.is_none() {
+        // No board to resolve against. `scope_board` is `None` both before the
+        // boards shape has synced and for a team that genuinely has none, so
+        // say that rather than making a claim about the repository — the same
+        // placeholder `file_tree` shows in this state.
+        if self.scope_board.is_none() {
+            return div()
+                .size_full()
+                .flex()
+                .items_center()
+                .justify_center()
+                .p_4()
+                .text_xs()
+                .text_color(theme.muted_foreground)
+                .child("Open a board to see its source control.")
+                .into_any_element();
+        }
+
+        // Scope not yet resolvable (teams/boards still syncing). `Idle` counts
+        // as in-flight: `ensure_scope` returns BEFORE it can start a load while
+        // the board is still unresolved, so gating only on `Loading` fell
+        // through to the definitive "no repository linked" notice during sync.
+        // That is a lie with a screenshot of its own — the store's
+        // `source-control` shot was exactly this state (EXP-566).
+        if matches!(self.scope_load, Load::Idle | Load::Loading) && self.scope.is_none() {
             return div()
                 .size_full()
                 .flex()

--- a/apps/web/src/lib/electric-proxy.ts
+++ b/apps/web/src/lib/electric-proxy.ts
@@ -8,6 +8,7 @@ import {
   recordSnapshotQueueWait,
   registerElectricProxyGauges,
 } from "@/lib/metrics/registry"
+import { isProductionBuild } from "@/lib/production-build"
 
 /**
  * REV-29: the ONLY inbound query params the proxy forwards to Electric —
@@ -226,8 +227,31 @@ export async function proxyElectricRequest(
  */
 const GZIP_MIN_BYTES = 1024
 
-/** Does this client's `Accept-Encoding` allow a gzip response? */
+/**
+ * Running under `vite dev` — as opposed to a built output OR vitest, both of
+ * which want the real code path. `isProductionBuild` (`import.meta.env.PROD`)
+ * is false for the dev server and vitest alike, so the VITEST env var is what
+ * separates them.
+ */
+const isDevServer = !isProductionBuild && !process.env.VITEST
+
+/**
+ * Does this client's `Accept-Encoding` allow a gzip response?
+ *
+ * Never under the DEV SERVER, whatever the client asked for. Dev routes every
+ * response through nitro's dev-worker HTTP hop, whose `fetch` transparently
+ * DECODES a gzip body while forwarding `content-encoding: gzip` untouched — so
+ * the client is handed plain JSON that its headers swear is compressed, and
+ * anything that believes the header (Bun's `fetch`, the desktop's ureq) dies on
+ * a decompression error instead of syncing. Compression is a production
+ * transfer optimisation and nothing in dev is served over a network worth
+ * optimising, so the honest thing is to skip it rather than lie about it.
+ * Scoped to the dev SERVER, not merely "unbuilt": vitest is unbuilt too and its
+ * coverage of this function is worth keeping honest, so it must still see the
+ * real compression path.
+ */
 function acceptsGzip(acceptEncoding: string | null | undefined): boolean {
+  if (isDevServer) return false
   if (!acceptEncoding) return false
   return acceptEncoding
     .split(`,`)

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs"
 import { defineConfig, type PluginOption } from "vite"
 import { devtools } from "@tanstack/devtools-vite"
 import { tanstackStart } from "@tanstack/react-start/plugin/vite"
@@ -5,6 +6,66 @@ import viteReact from "@vitejs/plugin-react"
 import viteTsConfigPaths from "vite-tsconfig-paths"
 import tailwindcss from "@tailwindcss/vite"
 import { nitro } from "nitro/vite"
+
+/**
+ * Refuse to start the dev server on a Node that silently breaks it.
+ *
+ * On Node 26, `fetch` over a UNIX SOCKET resolves with the right status and the
+ * right body and ZERO response headers (the same server over TCP is fine — an
+ * undici regression). Nitro's dev worker is reached over exactly such a socket,
+ * so every TanStack Start route is served with all of its headers stripped:
+ * no `content-type` (Start itself then throws `expected content-type header to
+ * be set` in the browser), no `set-cookie` (login cannot work), and no
+ * `electric-handle`/`electric-offset` — which ARE the shape cursor, so every
+ * Electric client re-requests `offset=-1` forever and no collection ever syncs.
+ * Nothing about it looks like an error: the JSON is correct, the app renders,
+ * and it just never fills in. It cost a full screenshot-store refresh (EXP-566)
+ * before anyone noticed.
+ *
+ * `.tool-versions` already pins the supported major; this is the check that
+ * makes the pin bite on machines with no version manager installed. Dev server
+ * only — `vite build` runs the same config, and the production output is served
+ * by Bun, which is unaffected.
+ */
+function assertDevNodeVersion(): void {
+  const isDevServer =
+    process.argv.some((arg) => arg === `dev` || arg === `serve`) && !process.env.VITEST
+  if (!isDevServer) return
+
+  const current = Number(process.versions.node.split(`.`)[0])
+  let pinned: number | undefined
+  try {
+    const match = readFileSync(
+      new URL(`../../.tool-versions`, import.meta.url),
+      `utf8`
+    ).match(/^nodejs\s+(\d+)/m)
+    pinned = match ? Number(match[1]) : undefined
+  } catch {
+    /* no .tool-versions is not fatal */
+  }
+  if (pinned !== undefined && current === pinned) return
+
+  const pin = pinned === undefined ? `the version in .tool-versions` : `Node ${pinned}`
+  if (current >= 26) {
+    throw new Error(
+      [
+        `Node ${process.versions.node} cannot serve this app in dev.`,
+        `  Node 26 drops EVERY response header on unix-socket fetches, which is how`,
+        `  nitro's dev worker is reached — so Electric never syncs, login cannot set a`,
+        `  cookie, and the app renders but stays empty, with no error anywhere.`,
+        `  Use ${pin} (\`.tool-versions\`), e.g. with Homebrew:`,
+        `    PATH="/opt/homebrew/opt/node@${pinned ?? 24}/bin:$PATH" bun dev`,
+        `  Or serve the production build, which runs under Bun and is unaffected:`,
+        `    bun run build && PORT=5173 bun --env-file=.env .output/server/index.mjs`,
+      ].join(`\n`)
+    )
+  }
+  console.warn(
+    `[vite] Node ${process.versions.node} is not ${pin} (.tool-versions) — dev serving is unverified on it.`
+  )
+}
+
+assertDevNodeVersion()
 
 const plugins: PluginOption[] = [
   ...(process.env.DISABLE_TANSTACK_DEVTOOLS === `1` ? [] : [devtools()]),

--- a/packages/shots/src/capture-all.ts
+++ b/packages/shots/src/capture-all.ts
@@ -35,7 +35,12 @@ import {
   type Platform,
 } from "@exp/view-catalog"
 import { lastStoreCommit, scopeSince, type AffectedScope } from "./affected.ts"
-import { captureDesktop, resolveBinary, screenRecordingAllowed } from "./capture-desktop.ts"
+import {
+  captureDesktop,
+  mintSessionToken,
+  resolveBinary,
+  screenRecordingAllowed,
+} from "./capture-desktop.ts"
 import { fetchDemoIds, type DemoIds } from "./ids.ts"
 import { importNative, NATIVE_PLATFORMS } from "./import-native.ts"
 import { hasCommand, killChild, run, sleep, track, type Child } from "./lib/proc.ts"
@@ -524,6 +529,78 @@ function readEnvFile(): Record<string, string> {
   return out
 }
 
+/**
+ * Can a sync client actually consume this instance's shape proxy?
+ *
+ * Every lane photographs an app whose content arrives over Electric, but NOTHING
+ * downstream can tell "synced and genuinely empty" from "never synced": the
+ * desktop app renders skeletons and definitive empty states either way, the
+ * window is not flat, and `captureOne`'s variance gate is happy. A run against a
+ * server whose shape responses a client cannot advance therefore produces a full
+ * set of confidently-wrong screenshots and exits 0 — which is exactly what
+ * happened, twice, and cost a whole store refresh.
+ *
+ * The failure mode that caused it is invisible from the body alone, and its
+ * cause is two layers below anything this repo owns: on **node 26** a `fetch`
+ * over a UNIX SOCKET returns the right status and the right body with ZERO
+ * response headers (the same server over TCP is fine — it is an undici
+ * regression). Nitro's dev worker is reached over exactly such a socket, so
+ * `bun dev` serves every TanStack Start route with all of its headers gone: no
+ * `content-type`, no `set-cookie`, and no `electric-handle`/`electric-offset`.
+ * Those two ARE the shape cursor, so every shape re-requests `offset=-1`
+ * forever, no collection ever reaches `up-to-date`, and the desktop app
+ * photographs skeletons and "0 members in this team" while looking perfectly
+ * alive. `.tool-versions` pins node 24.11.1 for this reason; nothing enforces
+ * it, so a machine with a newer node on PATH breaks dev serving silently.
+ *
+ * So this asserts on the CONTRACT rather than on the data: the three headers
+ * without which no client can sync, and the encoding sanity that a body claiming
+ * to be plain must not actually be gzip. Cheap, one request, and it fires before
+ * a single window is opened.
+ */
+async function assertShapesSyncable(baseUrl: string): Promise<void> {
+  const fix =
+    `The shape proxy is serving responses a sync client cannot advance.\n` +
+    `  This is what \`bun dev\` does on machines where dev-mode serving drops route headers.\n` +
+    `  Serve the built app instead (shots/README.md → Prerequisites):\n` +
+    `    cd apps/web && bun run build && PORT=5173 bun --env-file=.env .output/server/index.mjs`
+
+  let token: string
+  try {
+    token = await mintSessionToken(baseUrl)
+  } catch (error) {
+    throw new Error(
+      `could not sign in at ${baseUrl} to check the shape proxy: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+
+  const response = await fetch(`${baseUrl}/api/shapes/boards?offset=-1`, {
+    headers: { authorization: `Bearer ${token}`, origin: baseUrl },
+    // Bun-only: the instance may sit behind Caddy's self-signed dev certificate.
+    tls: { rejectUnauthorized: false },
+  })
+  if (!response.ok) {
+    throw new Error(`the boards shape answered ${response.status} ${response.statusText}. ${fix}`)
+  }
+
+  // `electric-handle` + `electric-offset` ARE the resumption cursor; without them
+  // a client re-requests offset=-1 forever and no shape ever reaches up-to-date.
+  const missing = [`content-type`, `electric-handle`, `electric-offset`].filter(
+    (header) => !response.headers.get(header)
+  )
+  if (missing.length > 0) {
+    throw new Error(`the boards shape response is missing ${missing.join(`, `)}. ${fix}`)
+  }
+
+  // A gzip body that does not say so decodes to garbage in any client that takes
+  // the header at its word — the desktop's ureq does.
+  const body = new Uint8Array(await response.arrayBuffer())
+  const gzipped = body[0] === 0x1f && body[1] === 0x8b
+  if (gzipped && !response.headers.get(`content-encoding`)) {
+    throw new Error(`the boards shape returned a gzip body with no content-encoding. ${fix}`)
+  }
+}
+
 /* --------------------------------------------------------------------- store */
 
 interface PlatformTally {
@@ -738,12 +815,24 @@ async function main(): Promise<number> {
         }
       }
 
+      // Before anything is driven: a server whose shape responses cannot be
+      // advanced yields a complete set of confidently-empty screenshots that
+      // every downstream check accepts. Fail here instead, in one request.
+      console.log(`\n── shape proxy ───────────────────────────────────────`)
+      await assertShapesSyncable(DEV_URL)
+      console.log(`  ok    ${DEV_URL}/api/shapes — control headers present, body decodable`)
+
+      // The relay stub comes BEFORE the id lookup on purpose: the demo user's own
+      // `devices` row is written by the stub as it announces itself, not by the
+      // seed, and `screenshots:ids` can only report a row that already exists. Ask
+      // first and `$device` is unresolvable on every freshly-seeded run — which
+      // silently skipped `machine-settings` (the Device settings dialog) forever.
+      if (relayNeeded) relay = await startRelayStub(options)
+
       ids = await fetchDemoIds()
       console.log(
-        `\nids: team ${ids.teamId} · ${Object.keys(ids.issues).length} issues${ids.supportThreadId ? ` · support thread ${ids.supportThreadId}` : ` · NO support thread (support views will skip)`}`
+        `\nids: team ${ids.teamId} · ${Object.keys(ids.issues).length} issues${ids.supportThreadId ? ` · support thread ${ids.supportThreadId}` : ` · NO support thread (support views will skip)`}${ids.deviceId ? `` : ` · NO device row (machine-settings will skip)`}`
       )
-
-      if (relayNeeded) relay = await startRelayStub(options)
 
       await captureWeb(options.platforms, options, scope, outcomes)
 

--- a/shots/README.md
+++ b/shots/README.md
@@ -176,5 +176,21 @@ merge, the just-merged PR added a route/view the catalog doesn't know: add the
 - **Flat/dark desktop shots** — Electric hadn't synced before the shutter; the
   capturer retries once with extra delay, but a slow first run may need a rerun
   of just that platform.
+- **`shape proxy` preflight fails / every desktop shot is skeletons and empty
+  states** — you are on the wrong Node. On **Node 26**, `fetch` over a unix
+  socket returns the right status and body with ZERO headers (TCP is fine — an
+  undici regression), and nitro's dev worker is reached over exactly such a
+  socket. So `bun dev` serves every TanStack Start route with its headers
+  stripped: no `content-type` (Start throws `expected content-type header to be
+  set` in the browser), no `set-cookie` (the web lane cannot log in), and no
+  `electric-handle`/`electric-offset` — the shape cursor, without which no
+  client ever syncs. The JSON is correct, so the app looks alive and just stays
+  empty. Use the Node pinned in `.tool-versions`:
+  `PATH="/opt/homebrew/opt/node@24/bin:$PATH" bun dev` — `vite.config.ts` now
+  refuses to start dev on a known-broken major. The built app is unaffected
+  (it runs under Bun) and is always a valid fallback:
+  `cd apps/web && bun run build && PORT=5173 bun --env-file=.env .output/server/index.mjs`.
+  The run also checks this in one request before opening a window, rather than
+  photographing forty empty shells and exiting 0.
 - **`screencapture` permission errors** — grant Screen Recording to the
   terminal app in System Settings → Privacy & Security, then rerun.


### PR DESCRIPTION
## Why

The desktop screenshot lane captured ~40 confidently-wrong screenshots — skeletons, `0 members in this team`, `No repository linked to this board.` — and exited 0. Twice.

The cause is two layers below this repo. On **Node 26**, `fetch` over a **unix socket** resolves with the right status and the right body and **zero response headers** (the same server over TCP is fine — an undici regression). Nitro pins `undici@^7` and reaches its dev worker over exactly such a socket, so the undici-7 `Agent` drives Node's undici-8 fetch handler, which reads the raw header list off `controller.rawHeaders` — a property undici 7's controller never sets.

Every TanStack Start route is then served with its headers stripped:

| missing | consequence |
| --- | --- |
| `content-type` | Start throws `Invariant failed: expected content-type header to be set` in the browser |
| `set-cookie` | login cannot work — the web capture lane never gets past `#email` |
| `electric-handle` / `electric-offset` | the shape cursor: every client re-requests `offset=-1` forever, nothing ever syncs |

Measured on one server, same code:

```
node v24.19.0  unix-socket  200  headers 7   ct=text/plain  handle=abc
node v26.5.0   unix-socket  200  headers 0   ct=null        handle=null
```

Nothing about it looks like an error: the JSON is correct, the app renders, it just never fills in.

## What changed

1. **`vite.config.ts` refuses to start the dev server on a known-broken major**, naming the cause and both escapes. `.tool-versions` already pinned the supported major; nothing enforced it (and `/opt/homebrew/opt/node@24` can itself be a symlink to a Node 26 keg). Dev server only — `vite build` shares this config, and the production output is served by Bun, which is unaffected.
2. **`electric-proxy.ts` stops lying about `content-encoding` in dev.** Once headers worked, a second dev-only defect surfaced: the same hop transparently *decodes* a gzip body while forwarding `content-encoding: gzip`, so clients that believe the header (Bun's `fetch`, the desktop's ureq) die on a decompression error. Skips outbound gzip under the dev server only — vitest is unbuilt too and keeps the real compression path.
3. **`capture-all.ts` gates the shape proxy before capturing.** Nothing downstream could tell "synced and genuinely empty" from "never synced", so this asserts the contract in one request before a single window opens.
4. **`capture-all.ts` resolves ids after the relay stub.** The demo `devices` row is written by the stub, not the seed, so `$device` was unresolvable on every freshly-seeded run and `machine-settings` skipped itself permanently.
5. **`source_control.rs` distinguishes resolving from "no repository".** `ensure_scope` leaves `scope_load` at `Idle` when no board has resolved, so gating on `Loading` alone showed a definitive "no repository" mid-sync. Mirrors the tri-state `file_tree.rs` already had.

## Verification

Against the **dev server** — the originally broken path:

- Desktop lane: 7/7 captured, **6 pixel-identical to the committed store images**, `machine-settings` captured for the first time, exit 0.
- Web lane: signs in and captures a fully synced board (previously could not find `#email`).
- The new gate fires correctly on a broken server, in seconds, before any window opens.
- `bun run typecheck` green across all four workspaces; 79 proxy tests; 23 shots tests; `cargo check -p ui` clean.

No screenshot or `view-catalog` changes are included — the store refresh is a separate unattended automation.

## Note for review

An alternative fix for (1) is a root `overrides` pinning `undici` to `^8`, aligning nitro's `Agent` with Node's bundled fetch and making dev work on Node 26 outright. It changes the dependency graph and `bun.lock`, so I left it as a call for you rather than bundling it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kbybj6Seb7eq2zxSaGjGxd