### PR TITLE
EXP-644: force UTF-8 locale for the iOS fastlane lanes

### DIFF
--- a/packages/shots/src/capture-all.ts
+++ b/packages/shots/src/capture-all.ts
@@ -521,6 +521,14 @@ async function captureFastlane(
     const result = await run({
       cmd,
       cwd: dir,
+      // fastlane's `snapshot` (iOS) shells out to the `simctl` gem, which reads
+      // `xcrun simctl list -j devicetypes` as US-ASCII when the process locale
+      // isn't UTF-8. A device type whose bundle path carries a non-ASCII byte
+      // (e.g. a stray "ʀ" in an "iPhone Xʀ" profile) then blows up JSON
+      // parsing; the gem swallows that and returns a bare identifier string,
+      // which fastlane calls `.name` on and crashes with a NoMethodError that
+      // looks nothing like an encoding issue (EXP-644).
+      env: platform === `ios` ? { LC_ALL: `en_US.UTF-8`, LANG: `en_US.UTF-8` } : undefined,
       stream: true,
       label: `[${platform}]`,
       timeoutMs: 90 * 60_000,


### PR DESCRIPTION
## Summary
- The iOS screenshot capture lanes crashed with `undefined method 'name' for an instance of String` before taking any screenshot.
- Root cause: fastlane's `snapshot` action uses the `simctl` gem to resolve device types via `xcrun simctl list -j devicetypes`. That gem reads the subprocess output in the ambient process locale; when it isn't UTF-8, a non-ASCII byte in a device type's bundle path (this machine has one with a stray "ʀ" in an "iPhone Xʀ" profile) breaks the JSON parse. The gem's `devicetype` rescues that exception and falls back to a raw identifier string, and fastlane then calls `.name` on it — producing a crash that looks nothing like an encoding problem.
- Fix: force `LC_ALL=en_US.UTF-8`/`LANG=en_US.UTF-8` on the iOS fastlane subprocess in the shots orchestrator (`packages/shots/src/capture-all.ts`), instead of relying on the operator's shell already having a UTF-8 locale (previously just a README prerequisite that's easy to forget).
- Verified: reproduced the crash directly against the `simctl` gem, confirmed setting the locale fixes it in isolation, then re-ran `bun run shots -- --platform ios --views sign-in` end-to-end — it captured cleanly with no errors.

## Test plan
- [x] `bun run --filter @exp/shots typecheck`
- [x] Reproduced the original crash via a standalone Ruby script against the `simctl` gem
- [x] Confirmed `LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8` resolves it in isolation
- [x] `bun run shots -- --platform ios --views sign-in` captured successfully end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)