### PR TITLE
EXP-669: pin the seeded comment timestamps and due dates so the demo stops churning

### DIFF
--- a/apps/web/scripts/lib/view-recipes.ts
+++ b/apps/web/scripts/lib/view-recipes.ts
@@ -157,14 +157,27 @@ async function recipeOpenFilterPopover(page: Page): Promise<void> {
 /**
  * Bring the issue's comment thread into frame. The composer is the last thing
  * in the timeline, so scrolling it into view puts the whole conversation on
- * screen; on the phone layout the composer lives in the floating bottom bar
- * instead, so the Activity header is the fallback target.
+ * screen; the phone layout keeps its composer in a floating bottom bar
+ * instead, so there the Activity header is the target.
+ *
+ * Which of the two applies is decided by the VIEWPORT, not by racing the
+ * composer against a timeout (EXP-669). It used to be the race, and the race
+ * was losable: on a cold-synced run the reply box needed longer than its 10s
+ * to mount, the recipe quietly took the phone branch, and
+ * `scrollIntoViewIfNeeded` on an Activity header that was already on screen
+ * did nothing at all — so the shot came back framed on the issue header, a
+ * different picture under the same filename, roughly one run in three. A
+ * missing composer at md+ is now a failure rather than a silent second frame.
  */
 async function recipeScrollToComments(page: Page): Promise<void> {
-  const hasComposer = await appears(page.getByPlaceholder(`Leave a reply…`), 10_000)
+  const width = page.viewportSize()?.width ?? 0
+  const hasComposer = width >= 768
   const target = hasComposer
     ? page.getByPlaceholder(`Leave a reply…`).first()
     : page.getByText(/^Activity/).first()
+  // Deliberately the same 20s the other recipes give a control they know is
+  // mounted: long enough for a first Electric sync, and loud when it is not.
+  await target.waitFor({ timeout: 20_000 })
   await target.scrollIntoViewIfNeeded({ timeout: 15_000 })
   // …then align it to the BOTTOM of the frame (EXP-670).
   // `scrollIntoViewIfNeeded` moves the MINIMUM distance that makes the target
@@ -180,9 +193,9 @@ async function recipeScrollToComments(page: Page): Promise<void> {
   // candidate and only accepts one whose `scrollTop` actually moved.
   //
   // ONLY on the composer path. The phone layout keeps its composer in a
-  // floating bottom bar, so the fallback target is the Activity header, and
-  // "scroll its container to the end" would mean something quite different
-  // there — it reframes the shot past the header it was asked to reach.
+  // floating bottom bar, so its target is the Activity header, and "scroll its
+  // container to the end" would mean something quite different there — it
+  // reframes the shot past the header it was asked to reach.
   if (hasComposer) {
     await target.evaluate((node) => {
       for (let el = node.parentElement; el; el = el.parentElement) {

--- a/apps/web/scripts/screenshot-demo.test.ts
+++ b/apps/web/scripts/screenshot-demo.test.ts
@@ -1,6 +1,7 @@
 import { formatDistanceToNowStrict } from "date-fns"
 import { describe, expect, it } from "vitest"
 import {
+  DEMO_DUE_DATES,
   DEMO_PENDING_INVITE_EXPIRY,
   DEMO_SHOWCASE_COMMENT_HOURS_AGO,
 } from "./screenshot-demo"
@@ -98,5 +99,34 @@ describe(`pinned showcase comment offsets (EXP-669)`, () => {
     for (const [, hours] of offsets) {
       expect(hours).toBeLessThan(3 * 24)
     }
+  })
+})
+
+describe(`pinned demo due dates (EXP-669)`, () => {
+  const dueDates = Object.entries(DEMO_DUE_DATES)
+
+  it.each(dueDates)(`%s is a real YYYY-MM-DD the clients can parse`, (_issue, due) => {
+    // `dueDateTone` compares these LEXICALLY against today, and desktop's
+    // `format_short_date` splits on the dashes — both quietly do the wrong
+    // thing with a malformed string rather than throwing.
+    expect(due).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    expect(new Date(`${due}T00:00:00Z`).toISOString().slice(0, 10)).toBe(due)
+  })
+
+  it.each(dueDates)(`%s stays far enough out to render as upcoming`, (_issue, due) => {
+    // Push the dates out (and re-capture the board views) when this fails.
+    // Every shot in the store has these rows muted; the day one of them goes
+    // overdue it turns red, and `board` sorts overdue-first, so the row moves
+    // too. Meant to fail with months to spare.
+    const runwayDays = (Date.parse(`${due}T00:00:00Z`) - Date.now()) / 86_400_000
+    expect(runwayDays).toBeGreaterThan(MIN_RUNWAY_DAYS)
+  })
+
+  it(`keeps the four on distinct days, soonest first`, () => {
+    // The order is the board's due-date spread, and EXP-668 is the standing
+    // reminder that a tie between two seeded rows is an unstable sort.
+    const values = dueDates.map(([, due]) => due)
+    expect(values).toStrictEqual([...values].sort())
+    expect(new Set(values).size).toBe(values.length)
   })
 })

--- a/apps/web/scripts/screenshot-demo.test.ts
+++ b/apps/web/scripts/screenshot-demo.test.ts
@@ -1,5 +1,9 @@
+import { formatDistanceToNowStrict } from "date-fns"
 import { describe, expect, it } from "vitest"
-import { DEMO_PENDING_INVITE_EXPIRY } from "./screenshot-demo"
+import {
+  DEMO_PENDING_INVITE_EXPIRY,
+  DEMO_SHOWCASE_COMMENT_HOURS_AGO,
+} from "./screenshot-demo"
 
 /** How much runway the pinned expiry must keep before this test starts failing. */
 const MIN_RUNWAY_DAYS = 120
@@ -22,5 +26,77 @@ describe(`pinned demo invite expiry (EXP-668)`, () => {
       date.getTime()
     )
     expect(new Set(times).size).toBe(times.length)
+  })
+})
+
+/**
+ * How long a capture run may take before a pinned comment offset is allowed to
+ * change what it renders.
+ *
+ * The gap that matters is seed -> shutter, and the last lane to photograph this
+ * thread is a native styleguide suite several lanes after the seed. Eight hours
+ * is far past any real run and still inside the 12-hour budget the fleet's
+ * bucket boundaries allow, so a failure here means an offset was moved to a bad
+ * place rather than that runs got slower.
+ */
+const COMMENT_LABEL_RUNWAY_HOURS = 8
+
+/** What web renders: date-fns `formatDistanceToNowStrict`, which ROUNDS. */
+const webLabel = (hoursAgo: number) =>
+  formatDistanceToNowStrict(new Date(Date.now() - hoursAgo * 3_600_000), {
+    addSuffix: true,
+  })
+
+/**
+ * What iOS, Android and desktop render: all three FLOOR on calendar
+ * boundaries, so they agree with each other and split from web in the back half
+ * of every day. Only the unit and count matter here, not the wording.
+ */
+const nativeLabel = (hoursAgo: number) =>
+  hoursAgo < 24 ? `${Math.floor(hoursAgo)}h` : `${Math.floor(hoursAgo / 24)}d`
+
+describe(`pinned showcase comment offsets (EXP-669)`, () => {
+  const offsets = Object.entries(DEMO_SHOWCASE_COMMENT_HOURS_AGO)
+
+  it.each(offsets)(
+    `%s renders the same label however late in the run the shutter fires`,
+    (_author, hours) => {
+      // Sampled rather than checked at the endpoints only: the label is
+      // monotonic in elapsed time, but sampling says WHICH hour broke it.
+      for (let elapsed = 0; elapsed <= COMMENT_LABEL_RUNWAY_HOURS; elapsed++) {
+        expect(webLabel(hours + elapsed)).toBe(webLabel(hours))
+        expect(nativeLabel(hours + elapsed)).toBe(nativeLabel(hours))
+      }
+    }
+  )
+
+  it.each(offsets)(
+    `%s is day-granular, which is what makes it survive that gap at all`,
+    (_author, hours) => {
+      expect(webLabel(hours)).toMatch(/^\d+ days? ago$/)
+      expect(nativeLabel(hours)).toMatch(/^\d+d$/)
+    }
+  )
+
+  it.each(offsets)(
+    `%s reads the same on web as on the natives, despite round vs floor`,
+    (_author, hours) => {
+      const webDays = webLabel(hours).match(/^(\d+) days? ago$/)?.[1]
+      expect(nativeLabel(hours)).toBe(`${webDays}d`)
+    }
+  )
+
+  it(`keeps the thread in order, newest last`, () => {
+    const hours = offsets.map(([, value]) => value)
+    expect(hours).toStrictEqual([...hours].sort((a, b) => b - a))
+    expect(new Set(hours).size).toBe(hours.length)
+  })
+
+  it(`posts every comment after the showcase issue was created`, () => {
+    // `seedIssues` gives APP-5 `createdDaysAgo: 3`; a comment seeded before
+    // that renders above the "created the issue" row and reads as nonsense.
+    for (const [, hours] of offsets) {
+      expect(hours).toBeLessThan(3 * 24)
+    }
   })
 })

--- a/apps/web/scripts/screenshot-demo.ts
+++ b/apps/web/scripts/screenshot-demo.ts
@@ -96,6 +96,44 @@ export const DEMO_PENDING_INVITE_EXPIRY = {
 } as const
 
 /**
+ * The due dates on the four issues that carry one (EXP-669).
+ *
+ * A due date renders as an ABSOLUTE `MMM d` chip on all five clients, so a
+ * relative offset moved it every calendar day and rewrote `board`,
+ * `issue-detail`, `issue-comments` and `my-issues` on the first refresh after
+ * midnight. Unlike a comment's relative label there is no bucket wide enough
+ * to hide in: the only stable absolute date is a fixed one.
+ *
+ * Spaced 1 / 2 / 4 / 7 days apart the way the relative offsets were, so the
+ * board's due column keeps the same order and spread, and parked in the same
+ * era as `DEMO_PENDING_INVITE_EXPIRY` so ONE bump moves every pinned date in
+ * this file. No client prints a year (web `formatDate`, iOS/Android `MMM d`,
+ * desktop `format_short_date` discards it outright), so a date two years out
+ * is pixel-identical in shape to next week's.
+ *
+ * They must all stay in the FUTURE: `dueDateTone` is a three-way rule and an
+ * upcoming date is the muted one every current shot shows. `screenshot-demo.test.ts`
+ * fails on `MIN_RUNWAY_DAYS` of headroom, long before one goes overdue and
+ * reddens a row.
+ *
+ * Note this deliberately costs one thing: at `inDays(1)` the deep-links issue
+ * rendered the literal "Tomorrow" on iOS and Android, which those two
+ * special-case. A fixed date cannot say that, so the mobile chip now reads
+ * `Jun 8` like everywhere else. Churning `board` on web and desktop every
+ * night was the worse trade.
+ */
+export const DEMO_DUE_DATES = {
+  /** `Push notification deep links open the wrong tab` — the soonest. */
+  deepLinks: `2027-06-08`,
+  /** `Dark mode contrast pass across settings`. */
+  darkMode: `2027-06-09`,
+  /** `Reduce cold start below 800 ms` — APP-5, the showcase issue. */
+  coldStart: `2027-06-11`,
+  /** `Improve empty states with illustrations` — the furthest out. */
+  emptyStates: `2027-06-14`,
+} as const
+
+/**
  * How long ago each comment on the showcase issue (APP-5) was posted, in hours
  * (EXP-669).
  *

--- a/apps/web/scripts/screenshot-demo.ts
+++ b/apps/web/scripts/screenshot-demo.ts
@@ -96,6 +96,45 @@ export const DEMO_PENDING_INVITE_EXPIRY = {
 } as const
 
 /**
+ * How long ago each comment on the showcase issue (APP-5) was posted, in hours
+ * (EXP-669).
+ *
+ * These are pinned for the same reason as the invite expiries above, but
+ * against a different mechanism. A comment renders a RELATIVE label the client
+ * computes against its own clock, so what reaches the pixel is not the seeded
+ * offset — it is the offset PLUS however long passed between the seed and the
+ * shutter. That gap is not a constant: it is a minute or two for a narrowed
+ * `--views issue-comments` run, most of an hour by the time the web-mobile
+ * lane reaches this view in a full refresh, and longer still for the native
+ * styleguide lanes that run last. With the old sub-day offsets the label was
+ * hour-granular and a bucket is one hour wide, so the same unchanged thread
+ * photographed "22 hours ago" one run and "23 hours ago" the next, rewriting
+ * every issue-comments shot for nothing.
+ *
+ * A DAY-granular label is the fix, because that bucket is wide enough to
+ * swallow the gap. It is only 12 hours wide across the fleet, though, not 24:
+ * web rounds (date-fns `formatDistanceToNowStrict`, so "1 day" is 24-36h)
+ * while iOS, Android and desktop floor on calendar boundaries ("1 day" is
+ * 24-48h). Their boundaries therefore fall every 12 hours, and an offset only
+ * survives the gap if it sits just ABOVE one — which is also where the two
+ * rules agree on what to print, so the same thread reads the same on all five
+ * platforms in the gallery.
+ *
+ * `screenshot-demo.test.ts` checks both rules against
+ * `COMMENT_LABEL_RUNWAY_HOURS`; edit these numbers only if it still passes.
+ */
+export const DEMO_SHOWCASE_COMMENT_HOURS_AGO = {
+  /** Mira opens with the profiling numbers. */
+  mira: 50,
+  /** Jonas picks up the snapshot cache. */
+  jonas: 49,
+  /** The demo user (Alex) posts the CI results. */
+  demo: 26,
+  /** Sofia's @mention + #issue-ref reply, the newest in the thread. */
+  sofia: 25,
+} as const
+
+/**
  * The LAST event of the scripted steering transcript: the unanswered question
  * the steering screenshot is composed around.
  *

--- a/apps/web/scripts/seed-screenshots.ts
+++ b/apps/web/scripts/seed-screenshots.ts
@@ -69,6 +69,7 @@ import {
   DEMO_PENDING_INVITE_EXPIRY,
   DEMO_NAME,
   DEMO_PASSWORD,
+  DEMO_DUE_DATES,
   DEMO_SERVER_VERSION,
   DEMO_SHOWCASE_COMMENT_HOURS_AGO,
   EMPTY_BOARD_SLUG,
@@ -114,8 +115,6 @@ if (frozenNow !== undefined) {
 const now = frozenNow ?? Date.now()
 const daysAgo = (d: number) => new Date(now - d * 86_400_000)
 const hoursAgo = (h: number) => new Date(now - h * 3_600_000)
-const inDays = (d: number) =>
-  new Date(now + d * 86_400_000).toISOString().slice(0, 10)
 
 /**
  * Attachment ids for the STORAGE settings view, minted up front so the seeded
@@ -471,7 +470,7 @@ async function main() {
       priority: `high`,
       assigneeId: demoId,
       creatorId: sofia,
-      dueDate: inDays(2),
+      dueDate: DEMO_DUE_DATES.darkMode,
       labels: [`Design`],
       createdDaysAgo: 5,
     },
@@ -492,7 +491,7 @@ async function main() {
       priority: `urgent`,
       assigneeId: jonas,
       creatorId: demoId,
-      dueDate: inDays(4),
+      dueDate: DEMO_DUE_DATES.coldStart,
       labels: [`Performance`],
       createdDaysAgo: 3,
     },
@@ -503,7 +502,7 @@ async function main() {
       priority: `urgent`,
       assigneeId: demoId,
       creatorId: mira,
-      dueDate: inDays(1),
+      dueDate: DEMO_DUE_DATES.deepLinks,
       labels: [`Bug`],
       createdDaysAgo: 2,
     },
@@ -522,7 +521,7 @@ async function main() {
       priority: `medium`,
       assigneeId: sofia,
       creatorId: demoId,
-      dueDate: inDays(7),
+      dueDate: DEMO_DUE_DATES.emptyStates,
       labels: [`Design`],
       createdDaysAgo: 7,
     },

--- a/apps/web/scripts/seed-screenshots.ts
+++ b/apps/web/scripts/seed-screenshots.ts
@@ -70,6 +70,7 @@ import {
   DEMO_NAME,
   DEMO_PASSWORD,
   DEMO_SERVER_VERSION,
+  DEMO_SHOWCASE_COMMENT_HOURS_AGO,
   EMPTY_BOARD_SLUG,
   NEWCOMER_EMAIL,
   NEWCOMER_NAME,
@@ -695,7 +696,11 @@ async function main() {
   inserted.push(duplicate)
 
   // Showcase issue APP-5: comments + activity + subscribers for the
-  // issue-detail and comments screenshots.
+  // issue-detail and comments screenshots. The offsets are pinned rather than
+  // written inline because a comment's relative label is the only thing in
+  // this thread that moves between runs (EXP-669) —
+  // `DEMO_SHOWCASE_COMMENT_HOURS_AGO` explains which offsets survive the gap
+  // between the seed and the shutter, and on which clients.
   const showcase = inserted[4]
   await db.insert(comments).values([
     {
@@ -704,7 +709,7 @@ async function main() {
       boardId: showcase.boardId,
       authorId: mira,
       body: `Profiled on a mid-range device — the shape subscribe alone is **410 ms**. Deferring it until after first frame gets us to ~750 ms cold.`,
-      createdAt: hoursAgo(26),
+      createdAt: hoursAgo(DEMO_SHOWCASE_COMMENT_HOURS_AGO.mira),
     },
     {
       issueId: showcase.id,
@@ -712,7 +717,7 @@ async function main() {
       boardId: showcase.boardId,
       authorId: jonas,
       body: `Nice find. I'll take the board snapshot cache — we can reuse the reducer state and paint before sync finishes.`,
-      createdAt: hoursAgo(22),
+      createdAt: hoursAgo(DEMO_SHOWCASE_COMMENT_HOURS_AGO.jonas),
     },
     {
       issueId: showcase.id,
@@ -720,7 +725,7 @@ async function main() {
       boardId: showcase.boardId,
       authorId: demoId,
       body: `Deferral PR is merged. CI numbers:\n\n- cold start: ~1.4s → **860 ms**\n- warm start: unchanged\n\nSnapshot cache should get us under target.`,
-      createdAt: hoursAgo(5),
+      createdAt: hoursAgo(DEMO_SHOWCASE_COMMENT_HOURS_AGO.demo),
     },
     // @mention + #issue ref so the comments screenshot shows both pill types
     // (interchange forms: plain `@<email>` and `#<IDENTIFIER>` GFM text).
@@ -730,7 +735,7 @@ async function main() {
       boardId: showcase.boardId,
       authorId: sofia,
       body: `@${TEAMMATES[1].email} once #APP-2 is verified on device, can you re-run the profiling? The HEIC fix might shave a little more off the cold start.`,
-      createdAt: hoursAgo(2),
+      createdAt: hoursAgo(DEMO_SHOWCASE_COMMENT_HOURS_AGO.sofia),
     },
   ])
   await db.insert(issueSubscribers).values([


### PR DESCRIPTION
Four screenshot views rewrote themselves on nearly every refresh with nothing behind it. EXP-670 fixed the scroll-offset half of `issue-comments`; this is the rest of what that PR named but did not land, plus the due dates that turned out to be a second, independent source.

## 1. Comment timestamps — a relative label plus a variable gap

A comment renders a **relative** label the client computes against its own clock, so what reaches the pixel is not the seeded offset — it is the offset **plus** the gap between the seed and the shutter. That gap is not a constant: a minute or two for a narrowed `--views issue-comments` run, most of an hour by the time the web-mobile lane reaches this view in a full refresh, longer still for the native styleguide lanes that run last.

The old offsets (26 / 22 / 5 / 2 hours) were hour-granular, and an hour bucket is one hour wide. So the same unchanged thread photographed "22 hours ago" one run and "23 hours ago" the next.

The pinned offsets are day-granular and sit just above a bucket floor. That budget is **12 hours, not 24**, because the fleet does not agree on the rule:

| | rule | "1 day ago" |
| --- | --- | --- |
| web | `formatDistanceToNowStrict` — **rounds** | 24–36 h |
| iOS / Android / desktop | **floor** on calendar boundaries | 24–48 h |

Boundaries therefore fall every 12 hours. Sitting just above one is also where the two rules agree on what to print, so the thread now reads the same on all five platforms instead of "2 days ago" on web and "1d" on the natives.

## 2. Due dates — an absolute date with nowhere to hide

A due date renders as an absolute `MMM d` chip everywhere, so `inDays(1/2/4/7)` moved it every calendar day and rewrote `board`, `issue-detail`, `issue-comments` and `my-issues` on the first refresh after midnight. There is no bucket to sit in; the only stable absolute date is a fixed one. Pinned the way `DEMO_PENDING_INVITE_EXPIRY` is, in the same era so one bump moves every pinned date in the file, and at the same 1 / 2 / 4 / 7 day spread so the board's due column holds its order.

All four stay in the future: `dueDateTone` is a three-way rule (overdue / today / upcoming) and upcoming — muted — is what every stored shot shows. No client prints a year for a due date (web `formatDate`, iOS `AppDateFormatters.MMMd`, Android `AppDate.monthDay`, desktop `format_short_date` discards it outright), so a date two years out is the same shape as next week's.

**One deliberate cost:** at `inDays(1)` the deep-links issue rendered the literal "Tomorrow", which iOS and Android special-case. A fixed date cannot say that, so the mobile chip now reads `Jun 8` like everywhere else. Churning `board` on web and desktop every night was the worse trade.

## 3. A losable race in the capture recipe

Found while verifying the above. `recipeScrollToComments` chose its layout branch by racing the composer against a 10 s timeout. On a cold-synced run the reply box needs longer than that, so the recipe silently took the phone branch — and `scrollIntoViewIfNeeded` on an Activity header that is already on screen does nothing at all, so the shot came back framed on the issue header instead. A different picture under the same filename, about one run in three.

It now branches on the viewport like `recipeOpenIssuePropertiesMobile` and `recipeOpenBoardSwitcher` already do, and a missing composer at md+ fails loudly instead of quietly producing a second frame. Without this the seed pins alone would not have stopped the churn.

## Tests

`screenshot-demo.test.ts` encodes the invariants, not the numbers: each comment offset must render the same label at every hour out to `COMMENT_LABEL_RUNWAY_HOURS` under **both** rules and web must agree with the natives; each due date must be a parseable `YYYY-MM-DD` more than `MIN_RUNWAY_DAYS` out, distinct, and soonest-first. Mutation-checked — the old `22` and a date in the past both fail, as does `37 h`, which sits in the round-vs-floor divergence band.

## Verification

Two consecutive full-seed capture runs over every affected view report **0 updated, 8 kept, +0 B** under `--views`, which writes on *any* change above the encoder-noise floor.

`shots/` is deliberately untouched: a seed change puts every view in scope, and the refresh action re-captures after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)